### PR TITLE
fix: manage.py init creates initial database

### DIFF
--- a/book/migrations/0001_initial.py
+++ b/book/migrations/0001_initial.py
@@ -60,8 +60,13 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='book',
             name='chapters',
-            field=models.ManyToManyField(default=None, to='document.Document', null=True, through='book.Chapter', blank=True),
+            field=models.ManyToManyField(to='document.Document', null=True, through='book.Chapter', blank=True),
             preserve_default=True,
+        ),
+        migrations.AlterField(
+            model_name='book',
+            name='chapters',
+            field=models.ManyToManyField(default=None, to=b'document.Document', null=True, through='book.Chapter', blank=True),
         ),
         migrations.AddField(
             model_name='book',


### PR DESCRIPTION
Fix for issue #108.

The init script fails during migrations of "books". Specifically migrations.AddField doesn't add the "chapters" many-to-many field when called with `default=None`.

The added AlterField was generated by `manage.py makemigrations`.

I don't understand why this is happening beyond this.
