### PR TITLE
User and citation footnotes

### DIFF
--- a/book/static/js/es6_modules/books/exporter/epub.js
+++ b/book/static/js/es6_modules/books/exporter/epub.js
@@ -10,7 +10,7 @@ import {ncxTemplate, ncxItemTemplate, navTemplate, navItemTemplate,
 import {node2Obj, obj2Node} from "../../exporter/json"
 import {createSlug, findImages} from "../../exporter/tools"
 import {zipFileCreator} from "../../exporter/zip"
-import {formatCitations} from "../../citations/format"
+import {FormatCitations} from "../../citations/format"
 
 
 export class EpubBookExporter extends BaseEpubExporter {
@@ -93,7 +93,7 @@ export class EpubBookExporter extends BaseEpubExporter {
                 contents.appendChild(tempNode.firstChild)
             }
 
-            let bibliography = formatCitations(contents,
+            let bibliography = new FormatCitations(contents,
                 this.book.settings.citationstyle,
                 this.bibDB)
 

--- a/book/static/js/es6_modules/books/exporter/epub.js
+++ b/book/static/js/es6_modules/books/exporter/epub.js
@@ -93,12 +93,12 @@ export class EpubBookExporter extends BaseEpubExporter {
                 contents.appendChild(tempNode.firstChild)
             }
 
-            let bibliography = new FormatCitations(contents,
+            let citationFormatter = new FormatCitations(contents,
                 this.book.settings.citationstyle,
                 this.bibDB)
 
-            if (bibliography.length > 0) {
-                contents.innerHTML += bibliography
+            if (citationFormatter.bibliographyHTML.length > 0) {
+                contents.innerHTML += citationFormatter.bibliographyHTML
             }
 
             images = images.concat(findImages(contents))

--- a/book/static/js/es6_modules/books/exporter/html.js
+++ b/book/static/js/es6_modules/books/exporter/html.js
@@ -6,7 +6,7 @@ import {obj2Node} from "../../exporter/json"
 import {BaseEpubExporter} from "../../exporter/epub"
 import {createSlug, findImages} from "../../exporter/tools"
 import {zipFileCreator} from "../../exporter/zip"
-import {formatCitations} from "../../citations/format"
+import {FormatCitations} from "../../citations/format"
 
 
 export class HTMLBookExporter extends BaseEpubExporter { // extension is correct. Neds orderLinks/setLinks methods from base epub exporter.
@@ -44,7 +44,7 @@ export class HTMLBookExporter extends BaseEpubExporter { // extension is correct
 
             let contents = obj2Node(aDocument.contents)
 
-            let bibliography = formatCitations(contents,
+            let bibliography = new FormatCitations(contents,
                 this.book.settings.citationstyle,
                 this.bibDB)
 

--- a/book/static/js/es6_modules/books/exporter/html.js
+++ b/book/static/js/es6_modules/books/exporter/html.js
@@ -44,12 +44,12 @@ export class HTMLBookExporter extends BaseEpubExporter { // extension is correct
 
             let contents = obj2Node(aDocument.contents)
 
-            let bibliography = new FormatCitations(contents,
+            let citationFormatter = new FormatCitations(contents,
                 this.book.settings.citationstyle,
                 this.bibDB)
 
-            if (bibliography.length > 0) {
-                contents.innerHTML += bibliography
+            if (citationFormatter.bibliographyHTML.length > 0) {
+                contents.innerHTML += citationFormatter.bibliographyHTML
             }
 
             let equations = contents.querySelectorAll('.equation')

--- a/book/static/js/es6_modules/print-book/print-book.js
+++ b/book/static/js/es6_modules/print-book/print-book.js
@@ -1,6 +1,6 @@
 import {bookPrintStartTemplate, bookPrintTemplate} from "./templates"
 import {obj2Node} from "../exporter/json"
-import {formatCitations} from "../citations/format"
+import {FormatCitations} from "../citations/format"
 
 /**
 * Helper functions for the book print page.
@@ -124,7 +124,7 @@ export class PrintBook {
         })
 
 
-        jQuery(bibliography).html(formatCitations(document.body, this.theBook.settings.citationstyle, this.bibDB))
+        jQuery(bibliography).html(new FormatCitations(document.body, this.theBook.settings.citationstyle, this.bibDB))
 
         if (jQuery(bibliography).text().trim().length===0) {
             jQuery(bibliography).parent().remove()

--- a/book/static/js/es6_modules/print-book/print-book.js
+++ b/book/static/js/es6_modules/print-book/print-book.js
@@ -123,8 +123,8 @@ export class PrintBook {
             obj2Node
         })
 
-
-        jQuery(bibliography).html(new FormatCitations(document.body, this.theBook.settings.citationstyle, this.bibDB))
+        let citationFormatter = new FormatCitations(document.body, this.theBook.settings.citationstyle, this.bibDB)
+        jQuery(bibliography).html(citationFormatter.bibliographyHTML)
 
         if (jQuery(bibliography).text().trim().length===0) {
             jQuery(bibliography).parent().remove()

--- a/document/static/css/footnotes.css
+++ b/document/static/css/footnotes.css
@@ -21,7 +21,7 @@
 
 /* footnotes in main editor */
 
-.footnote-marker::before {
+.footnote-marker::before, .citation-footnote-marker::before {
   counter-increment: footnote-marker-counter;
   content: counter(footnote-marker-counter);
 }

--- a/document/static/css/footnotes.css
+++ b/document/static/css/footnotes.css
@@ -46,7 +46,7 @@
   display: none;
 }
 
-.footnote-marker {
+.footnote-marker, .citation-footnote-marker {
   font-size: 75%;
   /*line-height: 0;*/
   position: relative;

--- a/document/static/css/footnotes.css
+++ b/document/static/css/footnotes.css
@@ -5,6 +5,11 @@
     vertical-align: top;
 }
 
+#citation-footnote-box-container {
+    position: absolute;
+    width: 20vw;
+}
+
 #footnote-box-container .footnote-container > *:first-child::before {
   counter-increment: footnote-counter;
   content: counter(footnote-counter) ' ';

--- a/document/static/css/footnotes.css
+++ b/document/static/css/footnotes.css
@@ -26,7 +26,7 @@
   content: counter(footnote-marker-counter);
 }
 
-.footnote-container {
+.footnote-container, .footnote-citation {
   margin-top: 10px;
 }
 

--- a/document/static/css/texteditor.css
+++ b/document/static/css/texteditor.css
@@ -468,7 +468,7 @@ figure img {
 #flow {
     background-color: white;
 }
-
+/*
 body {counter-reset: pagination-footnote pagination-footnote-reference;}
 #flow .pagination-footnote::before {
     counter-increment: pagination-footnote-reference;
@@ -486,7 +486,7 @@ body {counter-reset: pagination-footnote pagination-footnote-reference;}
     right: calc(-20vw - 10px);
     width: 20vw;
 }
-
+*/
 
 .figure-cat-figure::after {
     counter-increment: figure-cat-0;

--- a/document/static/js/es6_modules/citations/format.js
+++ b/document/static/js/es6_modules/citations/format.js
@@ -27,7 +27,6 @@ export class FormatCitations {
             this.renderCitations()
         }
         this.renderBibliography()
-        return this.bibliographyHTML
     }
 
     init() {

--- a/document/static/js/es6_modules/citations/format.js
+++ b/document/static/js/es6_modules/citations/format.js
@@ -4,210 +4,223 @@ import {CSLExporter} from "../bibliography/exporter/csl"
  * Functions to display citations and the bibliography.
  */
 
-export let formatCitations = function(contentElement, citationstyle, aBibDB) {
-     let bibliographyHTML = '',
-         allCitations = jQuery(contentElement).find('.citation'),
-         listedWorksCounter = 0,
-         citeprocParams = [],
-         bibFormats = [],
-         citationsIds = [],
-         cslGetter = new CSLExporter(aBibDB), // TODO: Figure out if this conversion should be done earlier and cached
-         cslDB = cslGetter.cslDB
-
-
-
-     allCitations.each(function(i) {
-         var entries = this.dataset.bibEntry ? this.dataset.bibEntry.split(',') : []
-         let allCitationsListed = true
-
-         let len = entries.length
-         for (let j = 0; j < len; j++) {
-             if (aBibDB.hasOwnProperty(entries[j])) {
-                 continue
-             }
-             allCitationsListed = false
-             break
-         }
-
-         if (allCitationsListed) {
-             let pages = this.dataset.bibPage ? this.dataset.bibPage.split(',,,') : [],
-                 prefixes = this.dataset.bibBefore ? this.dataset.bibBefore.split(',,,') : [],
-                 //suffixes = this.dataset.bibAfter.split(',,,'),
-                 citationItem,
-                 citationItems = []
-
-             listedWorksCounter += entries.length
-
-             for (let j = 0; j < len; j++) {
-                 citationItem = {
-                     id: entries[j]
-                 }
-                 if ('' != pages[j]) {
-                     citationItem.locator = pages[j]
-                 }
-                 if ('' != prefixes[j]) {
-                     citationItem.prefix = prefixes[j]
-                 }
-                 //if('' != suffixes[j]) { citationItem.suffix = pages[j] }
-                 citationItems.push(citationItem)
-             }
-
- //            bibFormats.push(i)
-             bibFormats.push(this.dataset.bibFormat)
-             citeprocParams.push({
-                 citationItems: citationItems,
-                 properties: {
-                     noteIndex: bibFormats.length
-                 }
-             })
-         }
-     })
-
-     if (listedWorksCounter == 0) {
-         return ''
-     }
-
-     let citeprocObj = getFormattedCitations(citeprocParams, citationstyle, bibFormats, cslDB)
-
-     for (let j = 0; j < citeprocObj.citations.length; j++) {
-         var citationText = citeprocObj.citations[j][0][1]
-         if ('note' == citeprocObj.citationtype) {
-             citationText = '<span class="pagination-footnote"><span><span>' + citationText + '</span></span></span>'
-         }
-         allCitations[j].innerHTML = citationText
-     }
-
-
-     bibliographyHTML += '<h1>' + gettext('Bibliography') + '</h1>'
-         // Add entry to bibliography
-
-     for (let j = 0; j < citeprocObj.bibliography[1].length; j++) {
-         bibliographyHTML += citeprocObj.bibliography[1][j]
-     }
-
-     return bibliographyHTML
-         // Delete entries that are exactly the same
-         //bibliographyHTML = _.unique(bibliographyHTML.split('<p>')).join('<p>')
-         //bibliographyHTML = bibliographyHTML.replace(/<div class="csl-entry">/g, '<p>')
-         //return bibliographyHTML.replace(/<\/div>/g, '</p>')
- }
-
-
-
-
-let getFormattedCitations = function (citations, citationStyle, citationFormats, cslDB) {
-
-    if (citeproc.styles.hasOwnProperty(citationStyle)) {
-        citationStyle = citeproc.styles[citationStyle]
-    } else {
-        for (styleName in citeproc.styles) {
-            citationStyle = citeproc.styles[styleName]
-            break
+export class FormatCitations {
+    constructor(contentElement, citationStyle, bibDB, renderNoteCitations = true) {
+        this.contentElement = contentElement
+        this.citationStyle = citationStyle
+        this.bibDB = bibDB
+        this.renderNoteCitations = renderNoteCitations
+        this.bibliographyHTML = ''
+        this.listedWorksCounter = 0
+        this.citations = []
+        this.bibFormats = []
+        //this.citationIds = []
+        this.citationTexts = []
+        this.citationType = ''
+        this.bibliography = ''
+        this.allCitations = []
+        this.cslDB = false
+        this.init()
+        this.formatAllCitations()
+        this.getFormattedCitations()
+        if (this.renderNoteCitations || 'note' !== this.citationType) {
+            this.renderCitations()
         }
+        this.renderBibliography()
+        return this.bibliographyHTML
     }
 
-    let citeprocInstance = new CSL.Engine(new citeprocSys(cslDB), citationStyle.definition)
+    init() {
+        this.allCitations = jQuery(this.contentElement).find('.citation')
+        let cslGetter = new CSLExporter(this.bibDB) // TODO: Figure out if this conversion should be done earlier and cached
+        this.cslDB = cslGetter.cslDB
+    }
 
-    let inText = citeprocInstance.cslXml.className === 'in-text'
+    formatAllCitations() {
+        let that = this
+        this.allCitations.each(function(i) {
+            var entries = this.dataset.bibEntry ? this.dataset.bibEntry.split(',') : []
+            let allCitationsListed = true
 
-    let len = citations.length
-
-    let citationTexts = []
-
-    for (let i = 0; i < len; i++) {
-        let citation = citations[i],
-            citationText = citeprocInstance.appendCitationCluster(citation)
-
-        if (inText && 'textcite' == citationFormats[i]) {
-            let newCiteText = '',
-                items = citation.citationItems,
-                len2 = items.length
-
-            for (let j = 0; j < len2; j++) {
-                let onlyNameOption = [{
-                    id: items[j].id,
-                    "author-only": 1
-                }]
-
-                let onlyDateOption = [{
-                    id: items[j].id,
-                    "suppress-author": 1
-                }]
-
-                if (items[j].locator) {
-                    onlyDateOption[0].locator = items[j].locator
+            let len = entries.length
+            for (let j = 0; j < len; j++) {
+                if (that.bibDB.hasOwnProperty(entries[j])) {
+                    continue
                 }
-
-                if (items[j].label) {
-                    onlyDateOption[0].label = items[j].label
-                }
-
-                if (items[j].prefix) {
-                    onlyDateOption[0].prefix = items[j].prefix
-                }
-
-                if (items[j].suffix) {
-                    onlyDateOption[0].suffix = items[j].suffix
-                }
-
-                if (0 < j) {
-                    newCiteText += '; '
-                }
-                newCiteText += citeprocInstance.makeCitationCluster(onlyNameOption)
-                newCiteText += ' ' + citeprocInstance.makeCitationCluster(onlyDateOption)
+                allCitationsListed = false
+                break
             }
 
-            citationText[0][1] = newCiteText
+            if (allCitationsListed) {
+                let pages = this.dataset.bibPage ? this.dataset.bibPage.split(',,,') : [],
+                    prefixes = this.dataset.bibBefore ? this.dataset.bibBefore.split(',,,') : [],
+                    //suffixes = this.dataset.bibAfter.split(',,,'),
+                    citationItem,
+                    citationItems = []
+
+                that.listedWorksCounter += entries.length
+
+                for (let j = 0; j < len; j++) {
+                    citationItem = {
+                        id: entries[j]
+                    }
+                    if ('' != pages[j]) {
+                        citationItem.locator = pages[j]
+                    }
+                    if ('' != prefixes[j]) {
+                        citationItem.prefix = prefixes[j]
+                    }
+                    //if('' != suffixes[j]) { citationItem.suffix = pages[j] }
+                    citationItems.push(citationItem)
+                }
+
+    //            that.bibFormats.push(i)
+                that.bibFormats.push(this.dataset.bibFormat)
+                that.citations.push({
+                    citationItems,
+                    properties: {
+                        noteIndex: that.bibFormats.length
+                    }
+                })
+            }
+        })
+
+        if (this.listedWorksCounter == 0) {
+            return ''
+        }
+    }
+
+    renderCitations() {
+        for (let j = 0; j < this.citationTexts.length; j++) {
+            let citationText = this.citationTexts[j][0][1]
+            if ('note' == this.citationType) {
+                citationText = '<span class="pagination-footnote"><span><span>' + citationText + '</span></span></span>'
+            }
+            this.allCitations[j].innerHTML = citationText
+        }
+    }
+
+    renderBibliography() {
+
+        this.bibliographyHTML += '<h1 id="bibliograhy-header"></h1>'
+            // Add entry to bibliography
+
+        for (let j = 0; j < this.bibliography[1].length; j++) {
+            this.bibliographyHTML += this.bibliography[1][j]
         }
 
-        citationTexts.push(citationText)
     }
 
-    return {
-        'citations': citationTexts,
-        'bibliography': citeprocInstance.makeBibliography(),
-        'citationtype': citeprocInstance.cslXml.className
-    }
-}
+    getFormattedCitations() {
 
-let stripValues = function(bibValue) {
-    return bibValue.replace(/[\{\}]/g, '')
-}
-
-let getAuthor = function(bibData) {
-    let author = bibData.author,
-        returnObject = {}
-    if ('' == author || 'undefined' == typeof(author)) {
-        author = bibData.editor
-    }
-    let splitAuthor = author.split("{")
-    if (splitAuthor.length > 2) {
-        returnObject.firstName = author.split("{")[1].replace(/[\{\}]/g, '').replace(/^\s\s*/, '').replace(/\s\s*$/, '')
-        returnObject.lastName = author.split("{")[2].replace(/[\{\}]/g, '').replace(/^\s\s*/, '').replace(/\s\s*$/, '')
-    } else {
-        returnObject.firstName = ''
-        returnObject.lastName = author.split("{")[1].replace(/[\{\}]/g, '').replace(/^\s\s*/, '').replace(/\s\s*$/, '')
-    }
-    return returnObject
-}
-
-let yearFromDateString = function(dateString) {
-    // This mirrors the formatting of the date as returned by Python in bibliography/models.py
-    let dates = dateString.split('/')
-    let newValue = []
-    for (let x = 0; x < dates.length; x++) {
-        let dateParts = dates[x].split('-')
-            // Only make use of the first value (to/from years), discarding month and day values
-        if (isNaN(dateParts[0])) {
-            break
+        if (citeproc.styles.hasOwnProperty(this.citationStyle)) {
+            this.citationStyle = citeproc.styles[this.citationStyle]
+        } else {
+            for (styleName in citeproc.styles) {
+                this.citationStyle = citeproc.styles[styleName]
+                break
+            }
         }
-        newValue.push(dateParts[0])
+
+        let citeprocInstance = new CSL.Engine(new citeprocSys(this.cslDB), this.citationStyle.definition)
+
+        let inText = citeprocInstance.cslXml.className === 'in-text'
+
+        let len = this.citations.length
+
+        for (let i = 0; i < len; i++) {
+            let citation = this.citations[i],
+                citationText = citeprocInstance.appendCitationCluster(citation)
+
+            if (inText && 'textcite' == this.bibFormats[i]) {
+                let newCiteText = '',
+                    items = citation.citationItems,
+                    len2 = items.length
+
+                for (let j = 0; j < len2; j++) {
+                    let onlyNameOption = [{
+                        id: items[j].id,
+                        "author-only": 1
+                    }]
+
+                    let onlyDateOption = [{
+                        id: items[j].id,
+                        "suppress-author": 1
+                    }]
+
+                    if (items[j].locator) {
+                        onlyDateOption[0].locator = items[j].locator
+                    }
+
+                    if (items[j].label) {
+                        onlyDateOption[0].label = items[j].label
+                    }
+
+                    if (items[j].prefix) {
+                        onlyDateOption[0].prefix = items[j].prefix
+                    }
+
+                    if (items[j].suffix) {
+                        onlyDateOption[0].suffix = items[j].suffix
+                    }
+
+                    if (0 < j) {
+                        newCiteText += '; '
+                    }
+                    newCiteText += citeprocInstance.makeCitationCluster(onlyNameOption)
+                    newCiteText += ' ' + citeprocInstance.makeCitationCluster(onlyDateOption)
+                }
+
+                citationText[0][1] = newCiteText
+            }
+
+            this.citationTexts.push(citationText)
+        }
+
+        this.citationType = citeprocInstance.cslXml.className
+        this.bibliography = citeprocInstance.makeBibliography()
     }
-    if (newValue.length === 0) {
-        return 'Unpublished'
-    } else if (newValue.length === 1) {
-        return newValue[0]
-    } else {
-        return newValue[0] + '-' + newValue[1]
+/*
+    stripValues(bibValue) {
+        return bibValue.replace(/[\{\}]/g, '')
     }
+
+    getAuthor(bibData) {
+        let author = bibData.author,
+            returnObject = {}
+        if ('' == author || 'undefined' == typeof(author)) {
+            author = bibData.editor
+        }
+        let splitAuthor = author.split("{")
+        if (splitAuthor.length > 2) {
+            returnObject.firstName = author.split("{")[1].replace(/[\{\}]/g, '').replace(/^\s\s*REMOVE/, '').replace(/\s\s*$/, '')
+            returnObject.lastName = author.split("{")[2].replace(/[\{\}]/g, '').replace(/^\s\s*REMOVE/, '').replace(/\s\s*$/, '')
+        } else {
+            returnObject.firstName = ''
+            returnObject.lastName = author.split("{")[1].replace(/[\{\}]/g, '').replace(/^\s\s*REMOVE/, '').replace(/\s\s*$/, '')
+        } // Remove strings "REMOVE" when reenabling this section
+        return returnObject
+    }*/
+
+    /*yearFromDateString(dateString) {
+        // This mirrors the formatting of the date as returned by Python in bibliography/models.py
+        let dates = dateString.split('/')
+        let newValue = []
+        for (let x = 0; x < dates.length; x++) {
+            let dateParts = dates[x].split('-')
+                // Only make use of the first value (to/from years), discarding month and day values
+            if (isNaN(dateParts[0])) {
+                break
+            }
+            newValue.push(dateParts[0])
+        }
+        if (newValue.length === 0) {
+            return 'Unpublished'
+        } else if (newValue.length === 1) {
+            return newValue[0]
+        } else {
+            return newValue[0] + '-' + newValue[1]
+        }
+    }*/
+
 }

--- a/document/static/js/es6_modules/editor/citations/mod.js
+++ b/document/static/js/es6_modules/editor/citations/mod.js
@@ -43,7 +43,7 @@ export class ModCitations {
             // bibliography hasn't been loaded yet
             return
         }
-
+        let needFootnoteLayout = false
         let emptyCitations = [].slice.call(document.querySelectorAll('#paper-editable span.citation:empty'))
         if (emptyCitations.length > 0) {
             let citationFormatter = new FormatCitations(
@@ -51,6 +51,10 @@ export class ModCitations {
                 this.editor.doc.settings.citationstyle,
                 this.editor.bibDB.bibDB, false
             )
+            if (this.citationType !== citationFormatter.citationType) {
+                // The citation format has changed, so we need to relayout the footnotes as well
+                needFootnoteLayout = true
+            }
             this.citationType = citationFormatter.citationType
 
             document.getElementById('document-bibliography').innerHTML = citationFormatter.bibliographyHTML
@@ -76,6 +80,9 @@ export class ModCitations {
             }
         }
         this.footnoteNumberOverride()
+        if (needFootnoteLayout) {
+            this.editor.mod.footnotes.layout.layoutFootnotes()
+        }
     }
 
     footnoteNumberOverride() {

--- a/document/static/js/es6_modules/editor/citations/mod.js
+++ b/document/static/js/es6_modules/editor/citations/mod.js
@@ -1,4 +1,4 @@
-import {formatCitations} from "../../citations/format"
+import {FormatCitations} from "../../citations/format"
 import {UpdateScheduler} from "prosemirror/dist/ui/update"
 
 export class ModCitations {
@@ -28,7 +28,7 @@ export class ModCitations {
         }
         let emptyCitations = document.querySelectorAll('#paper-editable span.citation:empty')
         if (emptyCitations.length > 0) {
-            let bibliographyHTML = formatCitations(
+            let bibliographyHTML = new FormatCitations(
                 document.getElementById('paper-editable'), // TODO: Should we point this to somewhere else?
                 this.editor.doc.settings.citationstyle,
                 this.editor.bibDB.bibDB

--- a/document/static/js/es6_modules/editor/citations/mod.js
+++ b/document/static/js/es6_modules/editor/citations/mod.js
@@ -5,7 +5,24 @@ export class ModCitations {
     constructor(editor) {
         editor.mod.citations = this
         this.editor = editor
+        this.citationType = ''
+        this.fnOverrideElement =  false
+        this.setup()
         this.bindEvents()
+    }
+
+    setup() {
+        /* Add a style to hold dynamic CSS info about footnote numbering overrides.
+         * Because we need footnotes in the editor and footnotes added through
+         * citations to be numbered but they aren't in the same order in the DOM,
+         * we need to organize the numbering manually.
+         */
+        let styleContainers = document.createElement('temp')
+        styleContainers.innerHTML = `<style type="text/css" id="footnote-numbering-override"></style>`
+        while (styleContainers.firstElementChild) {
+            document.head.appendChild(styleContainers.firstElementChild)
+        }
+        this.fnOverrideElement = document.getElementById('footnote-numbering-override')
     }
 
     bindEvents () {
@@ -26,6 +43,7 @@ export class ModCitations {
             // bibliography hasn't been loaded yet
             return
         }
+
         let emptyCitations = [].slice.call(document.querySelectorAll('#paper-editable span.citation:empty'))
         if (emptyCitations.length > 0) {
             let citationFormatter = new FormatCitations(
@@ -33,25 +51,64 @@ export class ModCitations {
                 this.editor.doc.settings.citationstyle,
                 this.editor.bibDB.bibDB, false
             )
+            this.citationType = citationFormatter.citationType
+
             document.getElementById('document-bibliography').innerHTML = citationFormatter.bibliographyHTML
             let citationsContainer = document.getElementById('citation-footnote-box-container')
-            if (citationFormatter.citationType==='note') {
+            if (this.citationType==='note') {
                 // The citations have not been filled, so we do so manually.
                 emptyCitations.forEach(function(emptyCitation) {
                     emptyCitation.innerHTML = '<span class="citation-footnote-marker"></span>'
                 })
                 let citationsHTML = ''
                 citationFormatter.citationTexts.forEach(function(citationText){
-                    citationsHTML += '<div class="footnote-citation">'+citationText+'</div>'
+                    citationsHTML += '<div class="footnote-citation">'+citationText[0][1]+'</div>'
                 })
                 if (citationsContainer.innerHTML !== citationsHTML) {
                     citationsContainer.innerHTML = citationsHTML
                 }
+
+
             } else {
                 if (citationsContainer.innerHTML !== '') {
                     citationsContainer.innerHTML = ''
                 }
             }
+        }
+        this.footnoteNumberOverride()
+    }
+
+    footnoteNumberOverride() {
+        /* Find the order of footnotes and citations in the document and
+         * write CSS to number all the citation footnotes and other footnotes
+         * correspondingly. Update footnote-numbering-override correspondingly.
+         */
+
+         let outputCSS = ''
+
+         if (this.citationType === 'note') {
+             let editorFootnoteCounter = 1,
+             citationFootnoteCounter = 1,
+             footnoteCounter = 1
+
+             this.editor.pm.doc.descendants(function(node){
+                 if (node.isInline && (node.type.name==='footnote' || node.type.name==='citation')) {
+                     if (node.type.name==='footnote') {
+                         outputCSS += '#footnote-box-container .footnote-container:nth-of-type('+editorFootnoteCounter+') > *:first-child::before {content: "' + footnoteCounter + ' ";}\n'
+                         editorFootnoteCounter++
+                     } else {
+                         outputCSS += '.footnote-citation:nth-of-type('+citationFootnoteCounter+')::before {content: "' + footnoteCounter + ' ";}\n'
+                         citationFootnoteCounter++
+                     }
+                     footnoteCounter++
+                 }
+             })
+
+
+         }
+
+        if (this.fnOverrideElement.innerHTML !== outputCSS) {
+            this.fnOverrideElement.innerHTML = outputCSS
         }
 
     }

--- a/document/static/js/es6_modules/editor/citations/mod.js
+++ b/document/static/js/es6_modules/editor/citations/mod.js
@@ -34,11 +34,23 @@ export class ModCitations {
                 this.editor.bibDB.bibDB, false
             )
             document.getElementById('document-bibliography').innerHTML = citationFormatter.bibliographyHTML
+            let citationsContainer = document.getElementById('citation-footnote-box-container')
             if (citationFormatter.citationType==='note') {
                 // The citations have not been filled, so we do so manually.
                 emptyCitations.forEach(function(emptyCitation) {
                     emptyCitation.innerHTML = '&thinsp;'
                 })
+                let citationsHTML = ''
+                citationFormatter.citationTexts.forEach(function(citationText){
+                    citationsHTML += '<div class="footnote-citation">'+citationText+'</div>'
+                })
+                if (citationsContainer.innerHTML !== citationsHTML) {
+                    citationsContainer.innerHTML = citationsHTML
+                }
+            } else {
+                if (citationsContainer.innerHTML !== '') {
+                    citationsContainer.innerHTML = ''
+                }
             }
         }
 

--- a/document/static/js/es6_modules/editor/citations/mod.js
+++ b/document/static/js/es6_modules/editor/citations/mod.js
@@ -26,14 +26,20 @@ export class ModCitations {
             // bibliography hasn't been loaded yet
             return
         }
-        let emptyCitations = document.querySelectorAll('#paper-editable span.citation:empty')
+        let emptyCitations = [].slice.call(document.querySelectorAll('#paper-editable span.citation:empty'))
         if (emptyCitations.length > 0) {
-            let bibliographyHTML = new FormatCitations(
+            let citationFormatter = new FormatCitations(
                 document.getElementById('paper-editable'), // TODO: Should we point this to somewhere else?
                 this.editor.doc.settings.citationstyle,
-                this.editor.bibDB.bibDB
+                this.editor.bibDB.bibDB, false
             )
-            document.getElementById('document-bibliography').innerHTML = bibliographyHTML
+            document.getElementById('document-bibliography').innerHTML = citationFormatter.bibliographyHTML
+            if (citationFormatter.citationType==='note') {
+                // The citations have not been filled, so we do so manually.
+                emptyCitations.forEach(function(emptyCitation) {
+                    emptyCitation.innerHTML = '&thinsp;'
+                })
+            }
         }
 
     }

--- a/document/static/js/es6_modules/editor/citations/mod.js
+++ b/document/static/js/es6_modules/editor/citations/mod.js
@@ -38,7 +38,7 @@ export class ModCitations {
             if (citationFormatter.citationType==='note') {
                 // The citations have not been filled, so we do so manually.
                 emptyCitations.forEach(function(emptyCitation) {
-                    emptyCitation.innerHTML = '&thinsp;'
+                    emptyCitation.innerHTML = '<span class="citation-footnote-marker"></span>'
                 })
                 let citationsHTML = ''
                 citationFormatter.citationTexts.forEach(function(citationText){

--- a/document/static/js/es6_modules/editor/tools/print.js
+++ b/document/static/js/es6_modules/editor/tools/print.js
@@ -40,10 +40,24 @@ export class ModToolsPrint {
         let footnoteMarkers = [].slice.call(flowCopy.querySelectorAll('.footnote-marker'))
 
         footnoteMarkers.forEach(function(fnMarker, index) {
+            while (fnMarker.firstChild) {
+                fnMarker.removeChild(fnMarker.firstChild)
+            }
             while (footnotes[index].firstChild) {
                 fnMarker.appendChild(footnotes[index].firstChild)
             }
         })
+        let footnoteCitations = footnoteBox.querySelectorAll('.footnote-citation')
+        let footnoteCitationMarkers = [].slice.call(flowCopy.querySelectorAll('.citation-footnote-marker'))
+
+        footnoteCitationMarkers.forEach(function(fnCitationMarker, index) {
+            let fnCitation = footnoteCitations[index]
+            fnCitation.classList.remove('footnote-citation')
+            fnCitationMarker.appendChild(fnCitation)
+            fnCitationMarker.classList.remove('citation-footnote-marker')
+            fnCitationMarker.classList.add('footnote-marker')
+        })
+
 
         window.flowCopy = flowCopy
         jQuery(flowTo).show()

--- a/document/static/js/es6_modules/exporter/html.js
+++ b/document/static/js/es6_modules/exporter/html.js
@@ -4,7 +4,7 @@ import {htmlExportTemplate} from "./html-templates"
 import {BibliographyDB} from "../bibliography/database"
 import {BaseExporter} from "./base"
 import {obj2Node} from "./json"
-import {formatCitations} from "../citations/format"
+import {FormatCitations} from "../citations/format"
 
 import {render as katexRender} from "katex"
 
@@ -57,7 +57,7 @@ export class BaseHTMLExporter extends BaseExporter{
             contents.insertBefore(tempNode, contents.firstChild)
         }
 
-        let bibliography = formatCitations(contents,
+        let bibliography = new FormatCitations(contents,
             this.doc.settings.citationstyle,
             this.bibDB)
 

--- a/document/static/js/es6_modules/exporter/html.js
+++ b/document/static/js/es6_modules/exporter/html.js
@@ -57,13 +57,15 @@ export class BaseHTMLExporter extends BaseExporter{
             contents.insertBefore(tempNode, contents.firstChild)
         }
 
-        let bibliography = new FormatCitations(contents,
+        let citationFormatter = new FormatCitations(contents,
             this.doc.settings.citationstyle,
             this.bibDB)
+            
+        let bibliographyHTML = citationFormatter.bibliographyHTML
 
-        if (bibliography.length > 0) {
+        if (bibliographyHTML.length > 0) {
             let tempNode = document.createElement('div')
-            tempNode.innerHTML = bibliography
+            tempNode.innerHTML = bibliographyHTML
             while (tempNode.firstChild) {
                 contents.appendChild(tempNode.firstChild)
             }

--- a/document/templates/document/editor.html
+++ b/document/templates/document/editor.html
@@ -471,7 +471,9 @@
             <div id="flow" class="comments-enabled CT-hide">
                 <div id="paper-editable">
                     <div id="document-editable" class="user-contents"></div>
-                    <div id="footnote-box-container"></div>
+                    <div id="footnote-box-container">
+                        <div id="citation-footnote-box-container"></div>
+                    </div>
                 </div>
                 <div id="document-bibliography" class="user-contents"></div>
             </div>


### PR DESCRIPTION
This patch reenables citations as footnotes for the citation styles that require this. This had to be done completely new as the 3.0 way of dealing with footnotes in a separate editor was incompatible with how citations in footnotes were layouted so far.