### PR TITLE
adding clientIDs to steps

### DIFF
--- a/document/static/js/es6_modules/editor/collab/doc-changes.js
+++ b/document/static/js/es6_modules/editor/collab/doc-changes.js
@@ -85,8 +85,16 @@ export class ModCollabDocChanges {
             let aPackage = {
                 type: 'diff',
                 diff_version: this.mod.editor.pm.mod.collab.version,
-                diff: toSend.steps.map(s => s.toJSON()),
-                footnote_diff: fnToSend.steps.map(s => s.toJSON()),
+                diff: toSend.steps.map(s => {
+                    let step = s.toJSON()
+                    step.client_id = this.mod.editor.pm.mod.collab.clientID
+                    return step
+                }),
+                footnote_diff: fnToSend.steps.map(s => {
+                    let step = s.toJSON()
+                    step.client_id = this.mod.editor.mod.footnotes.fnPm.mod.collab.clientID
+                    return step
+                }),
                 comments: this.mod.editor.mod.comments.store.unsentEvents(),
                 comment_version: this.mod.editor.mod.comments.store.version,
                 request_id: request_id,
@@ -94,8 +102,8 @@ export class ModCollabDocChanges {
             }
         this.mod.editor.mod.serverCommunications.send(aPackage)
         this.unconfirmedSteps[request_id] = {
-            diffs: toSend,
-            footnote_diffs: fnToSend,
+            diffs: toSend.steps,
+            footnote_diffs: fnToSend.steps,
             comments: this.mod.editor.mod.comments.store.hasUnsentEvents()
         }
         this.disableDiffSending()
@@ -148,12 +156,17 @@ export class ModCollabDocChanges {
     }
 
     confirmDiff(request_id) {
+        let that = this
         console.log('confirming steps')
         let sentSteps = this.unconfirmedSteps[request_id]["diffs"]
-        this.mod.editor.pm.mod.collab.confirmSteps(sentSteps)
+        this.mod.editor.pm.mod.collab.receive(sentSteps, sentSteps.map(function(step){
+            return that.mod.editor.pm.mod.collab.clientID
+        }))
 
         let sentFnSteps = this.unconfirmedSteps[request_id]["footnote_diffs"]
-        this.mod.editor.mod.footnotes.fnPm.mod.collab.confirmSteps(sentFnSteps)
+        this.mod.editor.mod.footnotes.fnPm.mod.collab.receive(sentFnSteps, sentFnSteps.map(function(step){
+            return that.mod.editor.mod.footnotes.fnPm.mod.collab.clientID
+        }))
 
         let sentComments = this.unconfirmedSteps[request_id]["comments"]
         this.mod.editor.mod.comments.store.eventsSent(sentComments)
@@ -172,7 +185,8 @@ export class ModCollabDocChanges {
     applyDiff(diff) {
         this.receiving = true
         let steps = [diff].map(j => Step.fromJSON(fidusSchema, j))
-        this.mod.editor.pm.mod.collab.receive(steps)
+        let client_ids = [diff].map(j => j.client_id)
+        this.mod.editor.pm.mod.collab.receive(steps, client_ids)
         this.receiving = false
     }
 

--- a/document/static/js/es6_modules/editor/footnotes/editor.js
+++ b/document/static/js/es6_modules/editor/footnotes/editor.js
@@ -52,7 +52,9 @@ export class ModFootnoteEditor {
 
     applyDiffs(diffs) {
         console.log('applying footnote diff')
-        this.mod.fnPm.mod.collab.receive(diffs.map(j => Step.fromJSON(this.mod.schema, j)))
+        let steps = diffs.map(j => Step.fromJSON(this.mod.schema, j))
+        let client_ids = diffs.map(j => j.client_id)
+        this.mod.fnPm.mod.collab.receive(steps, client_ids)
     }
 
     renderAllFootnotes() {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fidus-writer",
   "version": "2.9.0",
-  "description": "Install dependencies for ES6 compilation",
+  "description": "Install dependencies for ES6 transpilation",
   "scripts": {
   },
   "author": "Johannes Wilm",
@@ -11,7 +11,7 @@
     "browserify": "*",
     "babelify": "*",
     "babel-preset-es2015": "*",
-    "prosemirror": "git://github.com/ProseMirror/prosemirror.git#238a9f7810b8f407c1dca5c899fe24bbb6db99cd",
+    "prosemirror": "git://github.com/ProseMirror/prosemirror.git#6450c7aefb9e1abf7b41f916c9c89c291f6864a8",
     "katex": "0.5.1"
   },
   "browserify": {


### PR DESCRIPTION
Recently ProseMirror added clientID strings to each PM editor instance to prevent application of a step that originated at that same client, but where the confirmation from the server was lost in data traffic. This brings it top Fidus Writer