### PR TITLE
Issue: Table menu in the editor (3 dots) misplaced when the alignment…

### DIFF
--- a/document/static/css/document.css
+++ b/document/static/css/document.css
@@ -146,6 +146,7 @@ figure {
 .table-center {
     margin-left: auto !important;
     margin-right: auto !important;
+    clear: both;
 }
 
 .table-left {


### PR DESCRIPTION
Table menu in the editor (3 dots) misplaced when the alignment of an image above is changed
![table_handle](https://user-images.githubusercontent.com/45584170/53394268-c00d9680-39c4-11e9-9f7a-d608ba853deb.png)
