### PR TITLE
Fix for heading id generation

### DIFF
--- a/document/static/js/modules/document_template/fix_doc.js
+++ b/document/static/js/modules/document_template/fix_doc.js
@@ -151,7 +151,7 @@ export function adjustDocToTemplate(doc, template, documentStyles, citationStyle
                 )
             ) {
                 if (newNode.attrs.initial) {
-                    newNode.attrs.initial = newNode.content 
+                    newNode.attrs.initial = newNode.content
                 } else {
                     delete newNode.content
                 }

--- a/document/static/js/modules/document_template/fix_doc.js
+++ b/document/static/js/modules/document_template/fix_doc.js
@@ -151,7 +151,7 @@ export function adjustDocToTemplate(doc, template, documentStyles, citationStyle
                 )
             ) {
                 if (newNode.attrs.initial) {
-                    newNode.content = newNode.attrs.initial
+                    newNode.attrs.initial = newNode.content 
                 } else {
                     delete newNode.content
                 }


### PR DESCRIPTION
Previously Heading Id's weren't generated properly leading to issues in navigator and Table of contents.Fix for generating heading ID's properly when the document is loaded properly.