### PR TITLE
CSS fix to allow images side by side

### DIFF
--- a/fiduswriter/document/static/css/document.css
+++ b/fiduswriter/document/static/css/document.css
@@ -72,7 +72,7 @@ figure {
     break-inside: avoid;
     cursor: pointer;
     margin: 10%;
-    clear: both;
+    clear: none;
 }
 
 .aligned-right {
@@ -92,19 +92,27 @@ figure {
 }
 
 .image-width-100 {
-    width: 70%;
+    width: 80%;
+    box-sizing:border-box;
 }
 
 .image-width-75 {
     width: 55%;
+    box-sizing:border-box;
 }
 
 .image-width-50 {
     width: 40%;
+    margin-left:5%;
+    margin-right:5%;
+    box-sizing:border-box;
 }
 
 .image-width-25 {
-    width: 20%;
+    width: 21%;
+    margin-left:2%;
+    margin-right:2%;
+    box-sizing:border-box;
 }
 
 .figure-cat-figure::after {


### PR DESCRIPTION
Updated the CSS Rules to allow images to be placed side by side. Changed clear property of figure to none and updated CSS rules to adjust overlapping or overflowing of images.