### PR TITLE
Error msg fix

### DIFF
--- a/fiduswriter/usermedia/static/js/modules/images/database.js
+++ b/fiduswriter/usermedia/static/js/modules/images/database.js
@@ -40,8 +40,10 @@ export class ImageDB {
         ).then(
             ({json}) => {
                 deactivateWait()
+                console.log("json ", json)
                 if (Object.keys(json.errormsg).length) {
-                    return Promise.reject(new Error(json.errormsg))
+                    return Promise.reject(new Error(json.errormsg.error))
+
                 } else {
                     this.db[json.values.id] = json.values
                     return json.values.id
@@ -49,7 +51,14 @@ export class ImageDB {
             }
         ).catch(
             error => {
-                addAlert('error', gettext('Could not save image'))
+
+                if(error.message) {
+                    addAlert('error', gettext(error.message))
+                }
+                else{
+                    addAlert('error', gettext(error.statusText))
+                }
+
                 deactivateWait()
                 throw (error)
             }

--- a/fiduswriter/usermedia/static/js/modules/images/database.js
+++ b/fiduswriter/usermedia/static/js/modules/images/database.js
@@ -40,10 +40,8 @@ export class ImageDB {
         ).then(
             ({json}) => {
                 deactivateWait()
-                console.log("json ", json)
                 if (Object.keys(json.errormsg).length) {
                     return Promise.reject(new Error(json.errormsg.error))
-
                 } else {
                     this.db[json.values.id] = json.values
                     return json.values.id
@@ -51,14 +49,12 @@ export class ImageDB {
             }
         ).catch(
             error => {
-
                 if(error.message) {
                     addAlert('error', gettext(error.message))
                 }
                 else{
                     addAlert('error', gettext(error.statusText))
                 }
-
                 deactivateWait()
                 throw (error)
             }


### PR DESCRIPTION
Addressing 2 cases,

1. When we try to upload a file of different format ex :- gif
![image](https://user-images.githubusercontent.com/52812950/76414762-f8102d80-63bd-11ea-9eb6-df7aa36f514f.png)

On careful inspection of the response, we see this :- 

![image](https://user-images.githubusercontent.com/52812950/76414880-2f7eda00-63be-11ea-91d0-7f9c7b276f6b.png)

we are displaying this message in the error message :- 

![image](https://user-images.githubusercontent.com/52812950/76414941-4a514e80-63be-11ea-8c0c-4b10c0aec280.png)


2. When we try to upload image of size exceeding the value set by nginx server or any other load balancer.

![image](https://user-images.githubusercontent.com/52812950/76414794-08280d00-63be-11ea-8705-12b552846ffa.png)

On careful inspection of the request/response we see this ,

![image](https://user-images.githubusercontent.com/52812950/76414999-694fe080-63be-11ea-8ed8-2b7df0cedf0d.png)

So, now we will see :- 

![image](https://user-images.githubusercontent.com/52812950/76415036-7a005680-63be-11ea-9a8b-9528318cef2c.png)

