### PR TITLE
enable jest to unit-test js modules

### DIFF
--- a/fiduswriter/.eslintrc.js
+++ b/fiduswriter/.eslintrc.js
@@ -1,5 +1,6 @@
 module.exports = {
     "env": {
+        "jest": true,
         "browser": true,
         "es6": true
     },

--- a/fiduswriter/base/management/commands/jest.py
+++ b/fiduswriter/base/management/commands/jest.py
@@ -1,0 +1,33 @@
+import shutil
+import os
+from subprocess import call
+
+from django.core.management.base import BaseCommand
+from django.core.management import call_command
+from django.conf import settings
+
+
+class Command(BaseCommand):
+    help = 'Run jest unit tests.'
+
+    def handle(self, *ars, **options):
+        call_command('transpile')
+        shutil.os.chdir(
+            os.path.join(
+                settings.PROJECT_PATH,
+                '.transpile',
+            )
+        )
+        command_array = [
+            os.path.join(
+                settings.PROJECT_PATH,
+                ".transpile",
+                "node_modules",
+                ".bin",
+                "jest"
+            ),
+            "--no-cache",
+        ]
+        return_value = call(command_array)
+        if return_value > 0:
+            exit(return_value)

--- a/fiduswriter/base/package.json
+++ b/fiduswriter/base/package.json
@@ -37,6 +37,10 @@
   },
   "devDependencies": {
     "updates": "^10.2.0",
+    "eslint-plugin-jest": "^23.8.2",
+    "babel-jest": "^25.1.0",
+    "jest":"^25.1.0",
+    "updates": "^9.3.3",
     "@babel/cli": "7.6.x",
     "@babel/plugin-transform-template-literals": "^7.8.3"
   }


### PR DESCRIPTION
This PR provides the new management command 
`python manage.py jest`
to transpile all js modules and then run jest on the resulting files, executing all test-suites that have been found.

Please let me know when you have any questions or objections.