### PR TITLE
Fixes for issues related to comments.

### DIFF
--- a/fiduswriter/base/static/js/modules/app/index.js
+++ b/fiduswriter/base/static/js/modules/app/index.js
@@ -104,13 +104,14 @@ export class App {
         this.openOfflinePage = () => new OfflinePage(this.config)
         this.openSetupPage = () => new SetupPage(this.config)
         this.open404Page = () => new Page404(this.config)
+        this.handleSWUpdate = () => window.location.reload()
     }
 
     init() {
         if (!settings_DEBUG) {
             OfflinePluginRuntime.install({
                 onUpdateReady: () => OfflinePluginRuntime.applyUpdate(),
-                onUpdated: () => window.location.reload()
+                onUpdated: () => this.handleSWUpdate()
             })
         }
         ensureCSS([

--- a/fiduswriter/document/static/css/margin_boxes.css
+++ b/fiduswriter/document/static/css/margin_boxes.css
@@ -328,6 +328,10 @@ body.header-closed #margin-box-filter {
     border-bottom-color: var(--editor-active-comment-background-color);
 }
 
+.comment.active.resolved .comment-answer #answer-editor .ProseMirror-wrapper {
+    pointer-events: none;
+}
+
 .comment-is-major-bgc .comment-item:first-child {
     background-color: var(--editor-major-comment-background-color);
 }

--- a/fiduswriter/document/static/css/margin_boxes.css
+++ b/fiduswriter/document/static/css/margin_boxes.css
@@ -332,7 +332,7 @@ body.header-closed #margin-box-filter {
     background-color: var(--editor-major-comment-background-color);
 }
 
-.comment.resolved .comment-item {
+.comment.resolved .comment-item [class^=comment-] {
     opacity: var(--editor-comment-resolved-opacity);
 }
 

--- a/fiduswriter/document/static/js/modules/editor/comments/editors/answer.js
+++ b/fiduswriter/document/static/js/modules/editor/comments/editors/answer.js
@@ -12,7 +12,7 @@ export class CommentAnswerEditor extends CommentEditor {
         this.dom.insertAdjacentHTML(
             'beforeend',
             `<div class="comment-btns">
-                <button class="submit fw-button fw-dark" type="submit">
+                <button class="submit fw-button fw-dark ${this.mod.store.comments[this.id].comment && this.mod.store.comments[this.id].resolved ? 'disabled' : ''}" type="submit">
                     ${this.options.answerId ? gettext("Edit") : gettext("Submit")}
                 </button>
                 <button class="cancel fw-button fw-orange" type="submit">

--- a/fiduswriter/document/static/js/modules/editor/comments/editors/comment.js
+++ b/fiduswriter/document/static/js/modules/editor/comments/editors/comment.js
@@ -124,7 +124,7 @@ export class CommentEditor {
         this.dom.addEventListener('click', event => {
             const el = {}
             switch (true) {
-            case findTarget(event, 'button.submit', el):
+            case findTarget(event, 'button.submit:not(.disabled)', el):
                 this.submit()
                 break
             case findTarget(event, 'button.cancel', el):

--- a/fiduswriter/document/static/js/modules/editor/comments/interactions.js
+++ b/fiduswriter/document/static/js/modules/editor/comments/interactions.js
@@ -245,12 +245,12 @@ export class ModCommentInteractions {
     }
 
     recreateComment(id) {
-        if(this.editor) {
+        if (this.editor) {
             this.editor.dom.childNodes.forEach(node => {
                 if (node.classList && node.classList.contains("comment-btns")) {
                     node.childNodes.forEach(buttons => {
-                        if(buttons.classList && buttons.classList.contains("submit") && buttons.classList.contains("disabled")) {
-                                buttons.classList.remove("disabled")
+                        if (buttons.classList && buttons.classList.contains("submit") && buttons.classList.contains("disabled")) {
+                            buttons.classList.remove("disabled")
                         }
                     })
                 }

--- a/fiduswriter/document/static/js/modules/editor/comments/interactions.js
+++ b/fiduswriter/document/static/js/modules/editor/comments/interactions.js
@@ -245,6 +245,17 @@ export class ModCommentInteractions {
     }
 
     recreateComment(id) {
+        if(this.editor) {
+            this.editor.dom.childNodes.forEach(node => {
+                if (node.classList && node.classList.contains("comment-btns")) {
+                    node.childNodes.forEach(buttons => {
+                        if(buttons.classList && buttons.classList.contains("submit") && buttons.classList.contains("disabled")) {
+                                buttons.classList.remove("disabled")
+                        }
+                    })
+                }
+            })
+        }
         this.mod.store.updateComment({id, resolved: false})
     }
 

--- a/fiduswriter/document/static/js/modules/editor/menus/selection/model.js
+++ b/fiduswriter/document/static/js/modules/editor/menus/selection/model.js
@@ -47,10 +47,11 @@ export const selectionMenuModel = () => ({
                 editor.mod.comments.interactions.createNewComment()
                 return false
             },
-            disabled: editor => editor.currentView.state.selection.$anchor.depth < 2,
+            hidden: editor => editor.currentView.state.selection.$anchor.depth < 2,
             selected: editor => !!editor.currentView.state.selection.$head.marks().some(
                 mark => mark.type.name === 'comment'
             ),
+            disabled: false,
             order: 1
         },
         {
@@ -63,7 +64,7 @@ export const selectionMenuModel = () => ({
                 command(editor.currentView.state, tr => editor.currentView.dispatch(tr))
             },
             available: editor => !COMMENT_ONLY_ROLES.includes(editor.docInfo.access_rights),
-            disabled: editor => editor.currentView.state.selection.$anchor.depth < 2,
+            hidden: editor => editor.currentView.state.selection.$anchor.depth < 2,
             selected: editor => !!editor.currentView.state.selection.$head.marks().some(
                 mark => mark.type.name === 'anchor'
             ),
@@ -79,7 +80,7 @@ export const selectionMenuModel = () => ({
                 editor.currentView.state.selection.to
             ),
             available: editor => !COMMENT_ONLY_ROLES.includes(editor.docInfo.access_rights),
-            disabled: editor => editor.currentView.state.selection.$anchor.depth < 2 || !tracksInSelection(editor.currentView),
+            hidden: editor => editor.currentView.state.selection.$anchor.depth < 2 || !tracksInSelection(editor.currentView),
             order: 3
         },
         {
@@ -92,7 +93,7 @@ export const selectionMenuModel = () => ({
                 editor.currentView.state.selection.to
             ),
             available: editor => !COMMENT_ONLY_ROLES.includes(editor.docInfo.access_rights),
-            disabled: editor => editor.currentView.state.selection.$anchor.depth < 2 || !tracksInSelection(editor.currentView),
+            hidden: editor => editor.currentView.state.selection.$anchor.depth < 2 || !tracksInSelection(editor.currentView),
             order: 4
         }
     ]

--- a/fiduswriter/document/static/js/modules/editor/menus/selection/view.js
+++ b/fiduswriter/document/static/js/modules/editor/menus/selection/view.js
@@ -94,9 +94,7 @@ export class SelectionMenuView {
     getSelectionMenuHTML() {
         if (
             READ_ONLY_ROLES.includes(this.editor.docInfo.access_rights) ||
-            this.editorView.state.selection.empty ||
-            this.editor.mod.comments.store.commentDuringCreation ||
-            this.editor.mod.comments.interactions.activeCommentId
+            this.editorView.state.selection.empty
         ) {
             return '<div></div>'
         }
@@ -105,7 +103,7 @@ export class SelectionMenuView {
         return `<div style="margin-top: ${offset}px;">
             <div class="editor-selection-menu">
                 ${this.editor.menu.selectionMenuModel.content.map((menuItem, index) =>
-        `<div class="ui-buttonset${menuItem.disabled && menuItem.disabled(this.editor) ? ' disabled' : ''}">
+        `<div class="ui-buttonset${(menuItem.hidden && menuItem.hidden(this.editor)) || (menuItem.disabled && menuItem.disabled(this.editor)) ? ' disabled' : ''}">
                         ${this.getSelectionMenuItemHTML(menuItem, index)}
                     </div>`
     ).join('')}
@@ -114,7 +112,7 @@ export class SelectionMenuView {
     }
 
     getSelectionMenuItemHTML(menuItem, _index) {
-        if (menuItem.disabled && menuItem.disabled(this.editor)) {
+        if (menuItem.hidden && menuItem.hidden(this.editor)) {
             return ''
         } else {
             return this.getButtonHTML(menuItem)
@@ -123,7 +121,7 @@ export class SelectionMenuView {
 
     getButtonHTML(menuItem) {
         return `
-        <button aria-label="${menuItem.title}" class="fw-button fw-light fw-large fw-square edit-button${menuItem.selected && menuItem.selected(this.editor) ? ' ui-state-active' : ''}${menuItem.class ? ` ${menuItem.class(this.editor)}` : ''}" title="${menuItem.title}" >
+        <button aria-label="${menuItem.title}" class="fw-button fw-light fw-large fw-square edit-button${menuItem.selected && menuItem.selected(this.editor) ? ' ui-state-active' : ''}${menuItem.class ? ` ${menuItem.class(this.editor)}` : ''}${menuItem.disabled && menuItem.disabled(this.editor) ? ' disabled' : ''}" title="${menuItem.title}" >
             <span class="ui-button-text">
                 <i class="fa fa-${typeof(menuItem.icon) === 'function' ? menuItem.icon(this.editor) : menuItem.icon}"></i>
             </span>

--- a/fiduswriter/document/static/js/modules/editor/menus/selection/view.js
+++ b/fiduswriter/document/static/js/modules/editor/menus/selection/view.js
@@ -94,7 +94,9 @@ export class SelectionMenuView {
     getSelectionMenuHTML() {
         if (
             READ_ONLY_ROLES.includes(this.editor.docInfo.access_rights) ||
-            this.editorView.state.selection.empty
+            this.editorView.state.selection.empty ||
+            this.editor.mod.comments.store.commentDuringCreation ||
+            this.editor.mod.comments.interactions.isCurrentlyEditing()
         ) {
             return '<div></div>'
         }


### PR DESCRIPTION
This PR fixes minor bugs related to comments.

**_Fixes:_**
1. The options drop down in a resolved comment's answer had a lower opacity than the answer input field. This is now fixed.

![image](https://user-images.githubusercontent.com/46891412/88264413-5395e480-cce9-11ea-8282-3bef9bd69bc4.png)

2. Previously if there was an existing comment including a resolved comment was present in a piece of text , the entire selection menu was not rendered , because of which new comments could not be added. Now multiple comment threads are allowed for the same piece of text. 

3. The selection menu will be shown irrespective of whether there exists an active comment. But the option of accepting/rejecting a track changes are shown only if there are tracked changes within the selection. Do note the selection menu will be hidden if the comments are being edited. The below image shows the bug related to this fix :
![image](https://user-images.githubusercontent.com/46891412/88267487-89899780-ccee-11ea-8b41-e3757868e40a.png)

If we see the word sentence has a comment and the word test was written with track changes enabled. But in this scenario the selection menu that is shown at the side of the page is never rendered.


**Changes:**
Added a hook for handling SW updates.
