### PR TITLE
Disable track changes related options in Selection Menu

### DIFF
--- a/fiduswriter/document/static/js/modules/editor/document_template/index.js
+++ b/fiduswriter/document/static/js/modules/editor/document_template/index.js
@@ -63,6 +63,7 @@ export class ModDocumentTemplate {
             }))
         }
         const settingsMenu = this.editor.menu.headerbarModel.content.find(menu => menu.id === 'settings')
+        settingsMenu.content = settingsMenu.content.filter(item => item.id !== "metadata")
         settingsMenu.content.unshift(metadataMenu)
     }
 

--- a/fiduswriter/document/static/js/modules/editor/menus/selection/model.js
+++ b/fiduswriter/document/static/js/modules/editor/menus/selection/model.js
@@ -5,6 +5,7 @@ import {randomAnchorId} from "../../../schema/common"
 import {acceptAll, rejectAll} from "../../track"
 
 const tracksInSelection = view => {
+    // Check whether track marks are present within the range of selection
     let tracks = false
     const from = view.state.selection.from,
         to = view.state.selection.to

--- a/fiduswriter/document/static/js/modules/editor/menus/selection/model.js
+++ b/fiduswriter/document/static/js/modules/editor/menus/selection/model.js
@@ -63,7 +63,7 @@ export const selectionMenuModel = () => ({
                 const command = toggleMark(mark, {id: randomAnchorId()})
                 command(editor.currentView.state, tr => editor.currentView.dispatch(tr))
             },
-            available: editor => !COMMENT_ONLY_ROLES.includes(editor.docInfo.access_rights),
+            disabled: editor => COMMENT_ONLY_ROLES.includes(editor.docInfo.access_rights),
             hidden: editor => editor.currentView.state.selection.$anchor.depth < 2,
             selected: editor => !!editor.currentView.state.selection.$head.marks().some(
                 mark => mark.type.name === 'anchor'
@@ -79,7 +79,7 @@ export const selectionMenuModel = () => ({
                 editor.currentView.state.selection.from,
                 editor.currentView.state.selection.to
             ),
-            available: editor => !COMMENT_ONLY_ROLES.includes(editor.docInfo.access_rights),
+            disabled: editor => editor.docInfo.access_rights !== "write",
             hidden: editor => editor.currentView.state.selection.$anchor.depth < 2 || !tracksInSelection(editor.currentView),
             order: 3
         },
@@ -92,7 +92,7 @@ export const selectionMenuModel = () => ({
                 editor.currentView.state.selection.from,
                 editor.currentView.state.selection.to
             ),
-            available: editor => !COMMENT_ONLY_ROLES.includes(editor.docInfo.access_rights),
+            disabled: editor => editor.docInfo.access_rights !== "write",
             hidden: editor => editor.currentView.state.selection.$anchor.depth < 2 || !tracksInSelection(editor.currentView),
             order: 4
         }

--- a/fiduswriter/document/static/js/modules/editor/menus/selection/view.js
+++ b/fiduswriter/document/static/js/modules/editor/menus/selection/view.js
@@ -19,6 +19,8 @@ export class SelectionMenuView {
         this.openedMenu = false
         this.listeners = {}
 
+        this.removeUnavailable(this.editor.menu.selectionMenuModel)
+
         this.bindEvents()
         this.update()
     }


### PR DESCRIPTION
### Fixes issues related to track changes options in selection menu and multiple loading of the optional sections menu items

**Bug # 1 :** 
When user who has a write with tracked changes access rights , opens a document , the ability to accept/reject track changes Via the header bar menu and the individual track change menu is disabled. But the option to accept or reject a track change from the selection menu isn't disabled , allowing the user to accept/reject a track change.

**Bug # 2 :** 
Multiple loading of Optional sections menu. This issue is described in detail in the Issues. Issue #1043 

**Fixes :** 
Both of these issues are fixed with this merge request.