### PR TITLE
Offline improvements

### DIFF
--- a/fiduswriter/document/static/js/modules/documents/overview/index.js
+++ b/fiduswriter/document/static/js/modules/documents/overview/index.js
@@ -70,7 +70,6 @@ export class DocumentOverview {
             case findTarget(event, '.revisions', el):
                 if (this.app.isOffline()) {
                     addAlert('info', gettext("Cannot access revisions of a document when you're offline."))
-                    event.preventDefault()
                 } else {
                     docId = parseInt(el.target.dataset.id)
                     this.mod.actions.revisionsDialog(docId)
@@ -79,7 +78,6 @@ export class DocumentOverview {
             case findTarget(event, '.delete-document', el):
                 if (this.app.isOffline()) {
                     addAlert('info', gettext("Cannot delete a document when you're offline."))
-                    event.preventDefault()
                 } else {
                     docId = parseInt(el.target.dataset.id)
                     this.mod.actions.deleteDocumentDialog([docId])
@@ -88,7 +86,6 @@ export class DocumentOverview {
             case findTarget(event, '.owned-by-user.rights', el): {
                 if (this.app.isOffline()) {
                     addAlert('info', gettext("Cannot access access right data of a document when you're offline."))
-                    event.preventDefault()
                 } else {
                     docId = parseInt(el.target.dataset.id)
                     const dialog = new DocumentAccessRightsDialog(

--- a/fiduswriter/document/static/js/modules/documents/overview/index.js
+++ b/fiduswriter/document/static/js/modules/documents/overview/index.js
@@ -68,7 +68,7 @@ export class DocumentOverview {
             let docId
             switch (true) {
             case findTarget(event, '.revisions', el):
-                if(this.app.isOffline()) {
+                if (this.app.isOffline()) {
                     addAlert('info', gettext("Cannot access revisions of a document when you're offline."))
                     event.preventDefault()
                 } else {
@@ -77,7 +77,7 @@ export class DocumentOverview {
                 }
                 break
             case findTarget(event, '.delete-document', el):
-                if(this.app.isOffline()) {
+                if (this.app.isOffline()) {
                     addAlert('info', gettext("Cannot delete a document when you're offline."))
                     event.preventDefault()
                 } else {
@@ -86,7 +86,7 @@ export class DocumentOverview {
                 }
                 break
             case findTarget(event, '.owned-by-user.rights', el): {
-                if(this.app.isOffline()) {
+                if (this.app.isOffline()) {
                     addAlert('info', gettext("Cannot access access right data of a document when you're offline."))
                     event.preventDefault()
                 } else {
@@ -101,10 +101,10 @@ export class DocumentOverview {
                 break
             }
             case findTarget(event, 'a.doc-title', el):
-                if(this.app.isOffline()) {
+                if (this.app.isOffline()) {
                     addAlert('info', gettext("Cannot open a document when you're offline."))
                     event.preventDefault()
-                } 
+                }
                 break
             default:
                 break

--- a/fiduswriter/document/static/js/modules/documents/overview/index.js
+++ b/fiduswriter/document/static/js/modules/documents/overview/index.js
@@ -68,23 +68,44 @@ export class DocumentOverview {
             let docId
             switch (true) {
             case findTarget(event, '.revisions', el):
-                docId = parseInt(el.target.dataset.id)
-                this.mod.actions.revisionsDialog(docId)
+                if(this.app.isOffline()) {
+                    addAlert('info', gettext("Cannot access revisions of a document when you're offline."))
+                    event.preventDefault()
+                } else {
+                    docId = parseInt(el.target.dataset.id)
+                    this.mod.actions.revisionsDialog(docId)
+                }
                 break
             case findTarget(event, '.delete-document', el):
-                docId = parseInt(el.target.dataset.id)
-                this.mod.actions.deleteDocumentDialog([docId])
+                if(this.app.isOffline()) {
+                    addAlert('info', gettext("Cannot delete a document when you're offline."))
+                    event.preventDefault()
+                } else {
+                    docId = parseInt(el.target.dataset.id)
+                    this.mod.actions.deleteDocumentDialog([docId])
+                }
                 break
             case findTarget(event, '.owned-by-user.rights', el): {
-                docId = parseInt(el.target.dataset.id)
-                const dialog = new DocumentAccessRightsDialog(
-                    [docId],
-                    this.teamMembers,
-                    memberDetails => this.teamMembers.push(memberDetails)
-                )
-                dialog.init()
+                if(this.app.isOffline()) {
+                    addAlert('info', gettext("Cannot access access right data of a document when you're offline."))
+                    event.preventDefault()
+                } else {
+                    docId = parseInt(el.target.dataset.id)
+                    const dialog = new DocumentAccessRightsDialog(
+                        [docId],
+                        this.teamMembers,
+                        memberDetails => this.teamMembers.push(memberDetails)
+                    )
+                    dialog.init()
+                }
                 break
             }
+            case findTarget(event, 'a.doc-title', el):
+                if(this.app.isOffline()) {
+                    addAlert('info', gettext("Cannot open a document when you're offline."))
+                    event.preventDefault()
+                } 
+                break
             default:
                 break
             }

--- a/fiduswriter/document/static/js/modules/editor/index.js
+++ b/fiduswriter/document/static/js/modules/editor/index.js
@@ -389,8 +389,8 @@ export class Editor {
         if (this.ws) {
             this.ws.close()
         }
-        if(this.listeners.onBeforeUnload) {
-            window.removeEventListener("beforeunload",this.listeners.onBeforeUnload)
+        if (this.listeners.onBeforeUnload) {
+            window.removeEventListener("beforeunload", this.listeners.onBeforeUnload)
         }
     }
 
@@ -499,15 +499,15 @@ export class Editor {
                 showSystemMessage(gettext(
                     "The changes you made to the document will not be saved, if you close/refresh the tab or close the browser."
                 ))
-                event.preventDefault() 
+                event.preventDefault()
                 // To stop the event for chrome and safari
                 event.returnValue = 'Sure?'
                 return 'Sure?'
             }
-        };
+        }
         this.activateFidusPlugins()
         this.ws.init()
-        window.addEventListener("beforeunload",this.listeners.onBeforeUnload)
+        window.addEventListener("beforeunload", this.listeners.onBeforeUnload)
     }
 
     activateFidusPlugins() {

--- a/fiduswriter/document/static/js/modules/editor/index.js
+++ b/fiduswriter/document/static/js/modules/editor/index.js
@@ -497,7 +497,7 @@ export class Editor {
         this.listeners.onBeforeUnload = (event) => {
             if (this.app.isOffline()) {
                 showSystemMessage(gettext(
-                    "The changes you made to the document will not be saved, if you close/refresh the tab or close the browser."
+                    " Since you're offline the changes you made to the document will not be saved, if you choose to close/refresh the tab or close the browser."
                 ))
                 event.preventDefault()
                 // To stop the event for chrome and safari

--- a/fiduswriter/document/static/js/modules/editor/menus/headerbar/view.js
+++ b/fiduswriter/document/static/js/modules/editor/menus/headerbar/view.js
@@ -1,7 +1,6 @@
 import {DiffDOM} from "diff-dom"
 import {keyName} from "w3c-keyname"
-
-import {escapeText} from "../../../common"
+import {escapeText, addAlert} from "../../../common"
 
 export class HeaderbarView {
     constructor(editorView, options) {
@@ -52,8 +51,14 @@ export class HeaderbarView {
 
     onclick(event) {
         const target = event.target
-
-        if (target.matches('#headerbar #header-navigation .fw-pulldown-item')) {
+        if (target.matches("div#close-document-top a i.fa-times")) {
+            // If the user is offline prevent the closing of the document.
+            if (this.editor.app.isOffline()) {
+                event.preventDefault()
+                event.stopPropagation()
+                addAlert("info",gettext("Cannot close a document when you're offline."))
+            }
+        } else if (target.matches('#headerbar #header-navigation .fw-pulldown-item')) {
             // A header nav menu item was clicked. Now we just need to find
             // which one and execute the corresponding action.
             const searchPath = []

--- a/fiduswriter/document/static/js/modules/editor/menus/headerbar/view.js
+++ b/fiduswriter/document/static/js/modules/editor/menus/headerbar/view.js
@@ -56,7 +56,7 @@ export class HeaderbarView {
             if (this.editor.app.isOffline()) {
                 event.preventDefault()
                 event.stopPropagation()
-                addAlert("info",gettext("Cannot close a document when you're offline."))
+                addAlert("info", gettext("Cannot close a document when you're offline."))
             }
         } else if (target.matches('#headerbar #header-navigation .fw-pulldown-item')) {
             // A header nav menu item was clicked. Now we just need to find

--- a/fiduswriter/document/tests/test_collaboration.py
+++ b/fiduswriter/document/tests/test_collaboration.py
@@ -102,6 +102,8 @@ class OneUserTwoBrowsersTests(LiveTornadoTestCase, EditorHelper):
         body_input2 = self.driver2.find_element_by_class_name(
             'article-body'
         )
+        body_input.click()
+        body_input2.click()
 
         for char in self.TEST_TEXT:
             body_input.send_keys(char)
@@ -172,6 +174,8 @@ class OneUserTwoBrowsersTests(LiveTornadoTestCase, EditorHelper):
         body_input2 = self.driver2.find_element_by_class_name(
             'article-body'
         )
+        body_input.click()
+        body_input2.click()
 
         p1 = multiprocessing.Process(
             target=self.input_text,

--- a/fiduswriter/document/tests/test_editor.py
+++ b/fiduswriter/document/tests/test_editor.py
@@ -104,7 +104,8 @@ class EditorTest(LiveTornadoTestCase, SeleniumHelper):
                 "ul > li:nth-child(4) > span > label"
             )
         ).click()
-        # We type in th body
+        # We type in the body
+        self.driver.find_element(By.CSS_SELECTOR, ".article-body").click()
         self.driver.find_element(By.CSS_SELECTOR, ".article-body").send_keys(
             "Body"
         )

--- a/fiduswriter/document/tests/test_offline.py
+++ b/fiduswriter/document/tests/test_offline.py
@@ -691,6 +691,19 @@ class FunctionalOfflineTests(LiveTornadoTestCase, EditorHelper):
             0
         )
 
+        # Come back online to prevent pop up from showing up.
+        self.driver.execute_script(
+            'window.theApp.page.ws.goOnline()'
+        )
+        self.driver.execute_script(
+            'window.theApp.ws.goOnline()'
+        )
+        WebDriverWait(self.driver, self.wait_time).until(
+            lambda driver: driver.execute_script(
+                'return window.theApp.ws.connected'
+            )
+        )
+
     def test_indexedDB(self):
         """
         Testing a user going offline after logging in.


### PR DESCRIPTION
**Improvements:**

- Prevent offline users from opening a document, accessing access rights dialog , accessing revisions from document overview page.
- Prevent offline users from closing a document by clicking on the close icon when offline.
- Show a pop up/warning to offline users , when they try to close or refresh the tab or close the window while the editor is open.

**Screenshots:**
Preventing users from accidentally closing the tab or window , or refresh the tab when the editor is open.
![image](https://user-images.githubusercontent.com/46891412/91277617-b246f600-e7a0-11ea-89f6-6753719264a5.png)
