### PR TITLE
Scroll to active margin box referrer and fix scroll for internal links pointing to figure

### DIFF
--- a/fiduswriter/document/static/js/modules/editor/index.js
+++ b/fiduswriter/document/static/js/modules/editor/index.js
@@ -492,7 +492,7 @@ export class Editor {
             if (foundPos) {
                 return
             } else if ((node.type.groups.includes('heading') || node.type.name === 'figure') && node.attrs.id === id) {
-                foundPos = pos + 1
+                foundPos = node.type.name === 'figure' ? pos : pos + 1
                 view = this.view
             } else {
                 const anchorMark = node.marks.find(mark => mark.type.name === 'anchor')
@@ -508,7 +508,7 @@ export class Editor {
                 if (foundPos) {
                     return
                 } else if ((node.type.groups.includes('heading') || node.type.name === 'figure') && node.attrs.id === id) {
-                    foundPos = pos + 1
+                    foundPos = node.type.name === 'figure' ? pos : pos + 1
                     view = this.mod.footnotes.fnEditor.view
                 } else {
                     const anchorMark = node.marks.find(mark => mark.type.name === 'anchor')

--- a/fiduswriter/document/static/js/modules/editor/marginboxes/index.js
+++ b/fiduswriter/document/static/js/modules/editor/marginboxes/index.js
@@ -355,6 +355,16 @@ export class ModMarginboxes {
                         totalOffset += mboxPlacement.height + 2
                         return css
                     }).join('')
+                    
+                    if (firstActiveIndex > -1) {
+                        const topMenuHeight = this.editor.dom.querySelector('header').offsetHeight;
+                        const refDistanceFromTop = this.editor.view.coordsAtPos(referrers[firstActiveIndex]).top;
+
+                        if (refDistanceFromTop - topMenuHeight < 0 || refDistanceFromTop > window.innerHeight - 30) {
+                            const scrollTop = refDistanceFromTop - (topMenuHeight + 90)
+                            window.scrollBy({ left: 0, top: scrollTop, behavior: "smooth", block: "center" })
+                        }
+                    }
                 }
 
                 fastdom.mutate(() => {

--- a/fiduswriter/document/static/js/modules/editor/marginboxes/index.js
+++ b/fiduswriter/document/static/js/modules/editor/marginboxes/index.js
@@ -355,14 +355,13 @@ export class ModMarginboxes {
                         totalOffset += mboxPlacement.height + 2
                         return css
                     }).join('')
-                    
                     if (firstActiveIndex > -1) {
-                        const topMenuHeight = this.editor.dom.querySelector('header').offsetHeight;
-                        const refDistanceFromTop = this.editor.view.coordsAtPos(referrers[firstActiveIndex]).top;
+                        const topMenuHeight = this.editor.dom.querySelector('header').offsetHeight
+                        const refDistanceFromTop = this.editor.view.coordsAtPos(referrers[firstActiveIndex]).top
 
                         if (refDistanceFromTop - topMenuHeight < 0 || refDistanceFromTop > window.innerHeight - 30) {
                             const scrollTop = refDistanceFromTop - (topMenuHeight + 90)
-                            window.scrollBy({ left: 0, top: scrollTop, behavior: "smooth", block: "center" })
+                            window.scrollBy({left: 0, top: scrollTop, behavior: "smooth", block: "center"})
                         }
                     }
                 }


### PR DESCRIPTION
This PR included below things:
1. Fix scrolling for internal links pointing to figure.
   - As figures are block nodes, pos+1 will refer to the element after the figure. So when an internal link to the figure is clicked, the window is scrolled to coordinates of pos+1 and the focus will be below the image.
2. Scrolling to active margin box referrer in the editor
   - When a comment or track change is selected and the referrer is not visible in the editor, the selected margin box would be activated but the user needs to scroll manually to check the active margin box.
   - This fix adds a feature to scroll to the margin box referrer position only if it is required i.e. the referrer is not in the editor visible view.

Scenario:
When we have multiple margin boxes for a text like below. Scroll down and click on the last comment, the comment will be repositioned beside text but this will not be visible to the user. User need to manually scroll to check the active margin box.
![image](https://user-images.githubusercontent.com/47244366/93468098-18d8b300-f90c-11ea-9749-4ed71dafe109.png)
