### PR TITLE
Table header cell fixes

### DIFF
--- a/fiduswriter/document/migrations/0008_fix_fidus_3_3_table_header.py
+++ b/fiduswriter/document/migrations/0008_fix_fidus_3_3_table_header.py
@@ -10,22 +10,6 @@ from django.core.files import File
 # Some Fidus Writer 3.9.0 and 3.9.1 installations will have empty table header cells
 FW_DOCUMENT_VERSION = 3.3
 
-ID_COUNTER = 0
-
-def update_initial_node(node):
-    global ID_COUNTER
-    if "type" in node:
-        if (
-            node["type"] == "table_header" and
-            (
-                not "content" in node or
-                len(node["content"]) == 0
-            )
-        ):  
-            node["content"] = [{"type": "paragraph"}]
-    if "content" in node:
-        for sub_node in node["content"]:
-            update_initial_node(sub_node)
 
 def update_node(node):
     if "contents" in node:  # revision
@@ -48,7 +32,7 @@ def update_node(node):
         bool(node["attrs"]["initial"])
     ):
         for sub_node in node["attrs"]["initial"]:
-            update_initial_node(sub_node)
+            update_node(sub_node)
 
 # from https://stackoverflow.com/questions/25738523/how-to-update-one-file-inside-zip-file-using-python
 def update_revision_zip(file_field, file_name):
@@ -63,9 +47,6 @@ def update_revision_zip(file_field, file_name):
                 if item.filename == 'document.json':
                     doc_string = zin.read(item.filename)
                     doc = json.loads(doc_string)
-                    if 'contents' in doc:
-                        doc['content'] = doc['contents']
-                        del doc['contents']
                     update_node(doc['content'])
                     zout.writestr(
                         item,

--- a/fiduswriter/document/migrations/0008_fix_fidus_3_3_table_header.py
+++ b/fiduswriter/document/migrations/0008_fix_fidus_3_3_table_header.py
@@ -1,0 +1,117 @@
+import os
+import json
+import zipfile
+import tempfile
+from decimal import Decimal
+
+from django.db import migrations, models
+from django.core.files import File
+
+# Some Fidus Writer 3.9.0 and 3.9.1 installations will have empty table header cells
+FW_DOCUMENT_VERSION = 3.3
+
+ID_COUNTER = 0
+
+def update_initial_node(node):
+    global ID_COUNTER
+    if "type" in node:
+        if (
+            node["type"] == "table_header" and
+            (
+                not "content" in node or
+                len(node["content"]) == 0
+            )
+        ):  
+            node["content"] = [{"type": "paragraph"}]
+    if "content" in node:
+        for sub_node in node["content"]:
+            update_initial_node(sub_node)
+
+def update_node(node):
+    if "contents" in node:  # revision
+        update_node(node["contents"])
+    if "type" in node:
+        if (
+            node["type"] == "table_header" and
+            (
+                not "content" in node or
+                len(node["content"]) == 0
+            )
+        ):
+            node["content"] = [{"type": "paragraph"}]
+    if "content" in node:
+        for sub_node in node["content"]:
+            update_node(sub_node)
+    if (
+        "attrs" in node and
+        "initial" in node["attrs"] and
+        bool(node["attrs"]["initial"])
+    ):
+        for sub_node in node["attrs"]["initial"]:
+            update_initial_node(sub_node)
+
+# from https://stackoverflow.com/questions/25738523/how-to-update-one-file-inside-zip-file-using-python
+def update_revision_zip(file_field, file_name):
+    # generate a temp file
+    tmpfd, tmpname = tempfile.mkstemp()
+    os.close(tmpfd)
+    # create a temp copy of the archive without filename
+    with zipfile.ZipFile(file_field.open(), 'r') as zin:
+        with zipfile.ZipFile(tmpname, 'w') as zout:
+            zout.comment = zin.comment # preserve the comment
+            for item in zin.infolist():
+                if item.filename == 'document.json':
+                    doc_string = zin.read(item.filename)
+                    doc = json.loads(doc_string)
+                    if 'contents' in doc:
+                        doc['content'] = doc['contents']
+                        del doc['contents']
+                    update_node(doc['content'])
+                    zout.writestr(
+                        item,
+                        json.dumps(doc)
+                    )
+                else:
+                    zout.writestr(item, zin.read(item.filename))
+    # replace with the temp archive
+    with open(tmpname, 'rb') as tmp_file:
+        file_field.save(file_name, File(tmp_file))
+    os.remove(tmpname)
+
+def update_documents(apps, schema_editor):
+    Document = apps.get_model('document', 'Document')
+    documents = Document.objects.all().iterator()
+    for document in documents:
+        if document.doc_version == Decimal(str(FW_DOCUMENT_VERSION)):
+            update_node(document.content)
+            for field in document._meta.local_fields:
+                if field.name == "updated":
+                    field.auto_now = False
+            document.save()
+
+    DocumentTemplate = apps.get_model('document', 'DocumentTemplate')
+    templates = DocumentTemplate.objects.all()
+    for template in templates:
+        if template.doc_version == Decimal(str(FW_DOCUMENT_VERSION)):
+            update_node(template.content)
+            template.save()
+
+    DocumentRevision = apps.get_model('document', 'DocumentRevision')
+    revisions = DocumentRevision.objects.all()
+    for revision in revisions:
+        if not revision.file_object:
+            revision.delete()
+            continue
+        if revision.doc_version == Decimal(str(FW_DOCUMENT_VERSION)):
+            update_revision_zip(revision.file_object, revision.file_name)
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('document', '0007_fix_fidus_3_3'),
+    ]
+
+    operations = [
+        migrations.RunPython(update_documents),
+    ]

--- a/fiduswriter/document/static/js/modules/maintenance/index.js
+++ b/fiduswriter/document/static/js/modules/maintenance/index.js
@@ -116,7 +116,7 @@ export class DocMaintenance {
                     bibliography: doc.bibliography,
                     comments: doc.comments,
                     version: doc.version,
-                    diffs: doc.last_diffs
+                    diffs: doc.diffs
                 }
             ), promises = [p1]
         if (doc.imageIds) {
@@ -167,7 +167,7 @@ export class DocMaintenance {
             ({json}) => {
                 const oldDoc = {
                     content: json.content,
-                    last_diffs: [],
+                    diffs: [],
                     bibliography: {},
                     comments: {},
                     title: json.title,

--- a/fiduswriter/document/static/js/modules/schema/convert.js
+++ b/fiduswriter/document/static/js/modules/schema/convert.js
@@ -874,7 +874,12 @@ const convertNodeV32 = function(node, ids = []) {
         break
     case 'table_cell':
         if (!node.content || !node.content.length) {
-            node.content = {type: 'paragraph'}
+            node.content = [{type: 'paragraph'}]
+        }
+        break
+    case 'table_header':
+        if (!node.content || !node.content.length) {
+            node.content = [{type: 'paragraph'}]
         }
         break
     case 'bullet_list':

--- a/fiduswriter/document/views.py
+++ b/fiduswriter/document/views.py
@@ -1047,15 +1047,15 @@ def save_doc(request):
     diffs = request.POST.get('diffs', False)
     version = request.POST.get('version', False)
     if content:
-        doc.content = content
+        doc.content = json.loads(content)
     if bibliography:
-        doc.bibliography = bibliography
+        doc.bibliography = json.loads(bibliography)
     if comments:
-        doc.comments = comments
+        doc.comments = json.loads(comments)
     if version:
         doc.version = version
     if diffs:
-        doc.diffs = diffs
+        doc.diffs = json.loads(diffs)
     doc.doc_version = FW_DOCUMENT_VERSION
     doc.save()
     return JsonResponse(
@@ -1167,7 +1167,7 @@ def save_template(request):
         # Only looking at fields that may have changed.
         content = request.POST.get('content', False)
         if content:
-            template.content = content
+            template.content = json.loads(content)
         template.doc_version = FW_DOCUMENT_VERSION
         template.save()
     return JsonResponse(


### PR DESCRIPTION
### Fixes

- Update empty table_header cells to have empty paragraphs instead of just being empty , so as to not violate the schema.
- Fix document update mechanism from Maintenance Section (admin panel)