### PR TITLE
Fix footnote rendering while auto merging

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,6 +48,7 @@ jobs:
         - document.tests.test_export
         - document.tests.test_admin
         - document.tests.test_message_exchange
+        - document.tests.test_merge
         - bibliography
         - usermedia
     steps:

--- a/fiduswriter/document/static/js/modules/editor/footnotes/editor.js
+++ b/fiduswriter/document/static/js/modules/editor/footnotes/editor.js
@@ -185,7 +185,7 @@ export class ModFootnoteEditor {
         const node = fnNodeToPmNode(content)
         let pos = 0
         for (let i = 0; i < index;i++) {
-            pos += this.view.state.doc.child(i).nodeSize
+            pos += tr.doc.child(i).nodeSize
         }
         tr.insert(pos, node)
     }

--- a/fiduswriter/document/tests/editor_helper.py
+++ b/fiduswriter/document/tests/editor_helper.py
@@ -86,3 +86,18 @@ class EditorHelper(SeleniumHelper):
             # The strings don't match.
             time.sleep(0.1)
             self.wait_for_doc_sync(driver, driver2, seconds - 0.1)
+
+    def add_footnote(self, driver, footnote_pos, footnote_content, footnote_num):
+        driver.execute_script(
+            f'window.testCaret.setSelection({footnote_pos},{footnote_pos})'
+        )
+        driver.find_element_by_xpath('//*[@title="Footnote"]').click()
+
+        driver.find_element_by_xpath(
+            f'//*[@id="footnote-box-container"]/div[2]/div[{footnote_num}]'
+        ).send_keys(footnote_content)
+
+        driver.find_element_by_class_name(
+            'article-body'
+        ).click()
+

--- a/fiduswriter/document/tests/editor_helper.py
+++ b/fiduswriter/document/tests/editor_helper.py
@@ -87,7 +87,13 @@ class EditorHelper(SeleniumHelper):
             time.sleep(0.1)
             self.wait_for_doc_sync(driver, driver2, seconds - 0.1)
 
-    def add_footnote(self, driver, footnote_pos, footnote_content, footnote_num):
+    def add_footnote(
+        self,
+        driver,
+        footnote_pos,
+        footnote_content,
+        footnote_num
+    ):
         driver.execute_script(
             f'window.testCaret.setSelection({footnote_pos},{footnote_pos})'
         )
@@ -100,4 +106,3 @@ class EditorHelper(SeleniumHelper):
         driver.find_element_by_class_name(
             'article-body'
         ).click()
-

--- a/fiduswriter/document/tests/test_merge.py
+++ b/fiduswriter/document/tests/test_merge.py
@@ -1,0 +1,225 @@
+import time
+import multiprocessing
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support.ui import WebDriverWait
+from selenium.webdriver.support import expected_conditions as EC
+from testing.testcases import LiveTornadoTestCase
+from .editor_helper import EditorHelper
+from document.ws_views import WebSocket
+from django.conf import settings
+import os
+from selenium.webdriver.common.action_chains import ActionChains
+from selenium.webdriver.common.keys import Keys
+from document.models import AccessRight
+
+
+class AutoMergeTests(LiveTornadoTestCase, EditorHelper):
+    """
+    Tests in which two browsers collaborate and the connection is interrupted.
+    """
+    user = None
+    TEST_TEXT = "Lorem ipsum dolor sit amet."
+    NEWLINE = "\n"
+    MULTILINE_TEST_TEXT = "Item 1\nItem 2\nItem 3\nItem 4"
+    fixtures = [
+        'initial_documenttemplates.json',
+        'initial_styles.json',
+    ]
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        driver_data = cls.get_drivers(2)
+        cls.driver = driver_data["drivers"][0]
+        cls.driver2 = driver_data["drivers"][1]
+        cls.client = driver_data["clients"][0]
+        cls.client2 = driver_data["clients"][1]
+        cls.wait_time = driver_data["wait_time"]
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.driver.quit()
+        cls.driver2.quit()
+        super().tearDownClass()
+
+    def setUp(self):
+        self.user = self.create_user()
+        self.login_user(self.user, self.driver, self.client)
+        self.login_user(self.user, self.driver2, self.client2)
+        self.doc = self.create_new_document()
+
+    def tearDown(self):
+        self.leave_site(self.driver)
+        self.leave_site(self.driver2)
+
+    def test_footnotes_automerge(self):
+        """
+        Test one client going offline in collaborative mode while both clients
+        continue to write and add footnotes, and other text
+        such that auto merge would be triggered and tracking changes would
+        be triggered.
+        """
+
+        self.load_document_editor(self.driver, self.doc)
+        self.load_document_editor(self.driver2, self.doc)
+
+        self.add_title(self.driver)
+        self.driver.find_element_by_class_name(
+            'article-body'
+        ).click()
+
+        # Add some initial text and wait for doc to be synced.
+        self.type_text(self.driver, self.TEST_TEXT)
+        self.wait_for_doc_sync(self.driver, self.driver2)
+        
+        # driver 2 goes offline
+        self.driver2.execute_script(
+            'window.theApp.page.ws.goOffline()'
+        )
+
+        # Online user adds some text
+        self.driver.execute_script(
+            'window.testCaret.setSelection(25,25)'
+        )
+        p1 = multiprocessing.Process(
+            target=self.type_text,
+            args=(self.driver, self.TEST_TEXT)
+        )
+        p1.start()
+
+        # Client 2 adds some text at the end.
+        self.driver2.execute_script(
+            'window.testCaret.setSelection(52,52)'
+        )
+        self.type_text(self.driver2, self.TEST_TEXT)
+
+        p1.join()
+
+        # Add some footnotes by the offline user at the end of the document
+        self.add_footnote(self.driver2, 69, "Test", 1)
+        self.add_footnote(self.driver2, 74, "Test", 2)
+                
+        # Online user adds some footnote
+        self.add_footnote(self.driver, 30, "Test", 1)
+        self.add_footnote(self.driver, 37, "Test", 2)
+        self.add_footnote(self.driver, 44, "Test", 3)
+        
+        # Reset the tracking limits to allow tracking of user edits
+        self.driver2.execute_script(
+            'window.theApp.page.mod.collab.doc.merge.trackOfflineLimit = 0'
+        )
+
+        # driver 2 goes online
+        self.driver2.execute_script(
+            'window.theApp.page.ws.goOnline()'
+        )
+
+        self.wait_for_doc_sync(self.driver, self.driver2)
+
+        self.assertEqual(
+            self.get_contents(self.driver2),
+            self.get_contents(self.driver)
+        )
+
+        ## Check that the footnote counters and editor is aligned.
+        footnote_containers = self.driver2.find_elements_by_class_name(
+            'footnote-marker'
+        )
+        self.assertEqual(
+            len(footnote_containers),
+            5
+        )
+
+        footnote_containers = self.driver.find_elements_by_class_name(
+            'footnote-marker'
+        )
+        self.assertEqual(
+            len(footnote_containers),
+            5
+        )
+
+    def test_list_item_automerge(self):
+        """
+        Test one client going offline in collaborative mode while both clients
+        continue to write and add footnotes, and other text
+        such that auto merge would be triggered and tracking changes would
+        be triggered.
+        """
+
+        self.load_document_editor(self.driver, self.doc)
+        self.load_document_editor(self.driver2, self.doc)
+
+        self.add_title(self.driver)
+        self.driver.find_element_by_class_name(
+            'article-body'
+        ).click()
+
+        # Add some initial text and wait for doc to be synced.
+        self.type_text(self.driver, self.TEST_TEXT)
+        self.type_text(self.driver, self.NEWLINE)
+        
+        # Add a list item
+        button = self.driver.find_element_by_xpath('//*[@title="Numbered list"]')
+        button.click()
+        self.type_text(self.driver, self.MULTILINE_TEST_TEXT)
+
+        self.wait_for_doc_sync(self.driver, self.driver2)
+        
+        # driver 2 goes offline
+        self.driver2.execute_script(
+            'window.theApp.page.ws.goOffline()'
+        )
+
+
+        # Offline user deletes list item in a specific way
+        self.driver2.execute_script(
+            'window.testCaret.setSelection(86,86)'
+        )
+        self.driver2.execute_script(
+            'window.testCaret.setSelection(56,86)'
+        )
+        self.driver2.find_element_by_class_name(
+            'article-body'
+        ).send_keys(Keys.BACKSPACE)
+        self.driver2.find_element_by_class_name(
+            'article-body'
+        ).send_keys(Keys.BACKSPACE)
+
+
+        # Online user adds some text
+        self.driver.execute_script(
+            'window.testCaret.setSelection(25,25)'
+        )
+        self.type_text(self.driver, self.TEST_TEXT)
+        
+
+        # Reset the tracking limits to allow tracking of user edits
+        self.driver2.execute_script(
+            'window.theApp.page.mod.collab.doc.merge.trackOfflineLimit = 0'
+        )
+        # driver 2 goes online
+        self.driver2.execute_script(
+            'window.theApp.page.ws.goOnline()'
+        )
+
+        self.wait_for_doc_sync(self.driver, self.driver2)
+
+        self.assertEqual(
+            self.get_contents(self.driver2),
+            self.get_contents(self.driver)
+        )
+
+        # Check that the list items aren't deleted
+        numberedTags = self.driver.find_elements_by_xpath(
+            '//*[contains(@class, "article-body")]//ol//li')
+        self.assertEqual(
+            len(numberedTags),
+            4
+        )
+        numberedTags = self.driver2.find_elements_by_xpath(
+            '//*[contains(@class, "article-body")]//ol//li')
+        self.assertEqual(
+            len(numberedTags),
+            4
+        )
+

--- a/fiduswriter/usermedia/models.py
+++ b/fiduswriter/usermedia/models.py
@@ -13,7 +13,7 @@ from django.core.files.uploadedfile import SimpleUploadedFile
 from document.models import Document
 
 ALLOWED_FILETYPES = ['image/jpeg', 'image/png', 'image/svg+xml']
-ALLOWED_EXTENSIONS = ['jpeg', 'jpg', 'png', 'svg','jfif']
+ALLOWED_EXTENSIONS = ['jpeg', 'jpg', 'png', 'svg', 'jfif']
 
 
 def get_file_path(instance, filename):

--- a/fiduswriter/usermedia/models.py
+++ b/fiduswriter/usermedia/models.py
@@ -13,7 +13,7 @@ from django.core.files.uploadedfile import SimpleUploadedFile
 from document.models import Document
 
 ALLOWED_FILETYPES = ['image/jpeg', 'image/png', 'image/svg+xml']
-ALLOWED_EXTENSIONS = ['jpeg', 'jpg', 'png', 'svg']
+ALLOWED_EXTENSIONS = ['jpeg', 'jpg', 'png', 'svg','jfif']
 
 
 def get_file_path(instance, filename):


### PR DESCRIPTION
**Fixes:**
- Fix trying to render multiple newly added footnote in one go while auto merging.

Add new tests for edge case scenarios while auto merging.
Allow uploading of images with 'jfif' extension (JPEG file interchange format).