### PR TITLE
retain user selection when auto-merging documents

### DIFF
--- a/fiduswriter/document/static/js/modules/editor/collab/merge/index.js
+++ b/fiduswriter/document/static/js/modules/editor/collab/merge/index.js
@@ -135,7 +135,7 @@ export class Merge {
                 }
             } else {
                 try {
-                    this.autoMerge(unconfirmedTr, lostTr, data)
+                    this.autoMerge(unconfirmedTr, lostTr, data, this.mod.editor.view.state.selection)
                 } catch (error) {
                     this.handleMergeFailure(error, unconfirmedTr.doc, toDoc)
                 }
@@ -152,10 +152,10 @@ export class Merge {
         }
     }
 
-    autoMerge(unconfirmedTr, lostTr, data) {
+    autoMerge(unconfirmedTr, lostTr, data, selection) {
         /* This automerges documents incase of no conflicts */
         const toDoc = this.mod.editor.schema.nodeFromJSON({type: "doc", content: [data.doc.content]})
-        const rebasedTr = EditorState.create({doc: toDoc}).tr.setMeta("remote", true)
+        const rebasedTr = EditorState.create({doc: toDoc, selection}).tr.setMeta("remote", true)
         const maps = new Mapping([].concat(unconfirmedTr.mapping.maps.slice().reverse().map(map => map.invert())).concat(lostTr.mapping.maps.slice()))
 
         unconfirmedTr.steps.forEach(


### PR DESCRIPTION
We are having an issue when multiple users are interacting a document, that the cursor jumps to the top of the page sometimes. I was able to narrow this down to the selection being reset after we autoMerge() is called. This update fixes it for me!

I would like to understand more why the selection is being overridden here in particular, and I wonder if there is anything else in the original state that may need to be included, or if there are other places that would need this? It doesn't appear that the new state created in the beginning of adjustDocument() affects selection.