### PR TITLE
Issue 1305 - Handle runserver command with addr:port argument

### DIFF
--- a/fiduswriter/base/management/commands/runserver.py
+++ b/fiduswriter/base/management/commands/runserver.py
@@ -166,18 +166,19 @@ class Command(RunserverCommand):
 
     def inner_run(self, *args, **options):
         # Determine ports to use
+        default_port = int(self.port)
         if self.addrport_provided:
-            ports = [self.port]
+            ports = [default_port]
         else:
-            ports = getattr(settings, "PORTS", [self.port])
+            ports = getattr(settings, "PORTS", [default_port])
             if isinstance(ports, int):
                 ports = [ports]
             elif isinstance(ports, (list, tuple)):
                 ports = list(ports)
             else:
-                ports = [self.port]
+                ports = [default_port]
             if not ports:
-                ports = [self.port]
+                ports = [default_port]
             try:
                 ports = [get_internal_port(p) for p in ports]
             except (ValueError, TypeError):


### PR DESCRIPTION
This proposes a fix for #1305 where the runserver command chokes on addr:port argument.

Please feel free to modify/reject if you wish to handle this a different way.
