### PR TITLE
django-npm-mjs==3.2.1

### DIFF
--- a/fiduswriter/requirements.txt
+++ b/fiduswriter/requirements.txt
@@ -6,7 +6,7 @@ Django==5.1.8
 django-allauth[socialaccount]==65.0.2
 django-avatar==8.0.1
 django-js-error-hook==1.0
-django-npm-mjs==3.2.0
+django-npm-mjs==3.2.1
 django-loginas==0.3.11
 httpx==0.27.2
 httpx-ws==0.6.2


### PR DESCRIPTION
This pulls in pyjson5==1.6.9 which is needed to build with Cython 3.1.x,
otherwise one may get the following failure building pyjson5:

src/_imports.pyx:12:0: 'cpython/int.pxd' not found