### PR TITLE
DEBUG: add logging around export template dialog in admin test

### DIFF
--- a/fiduswriter/document/templates/admin/document/documenttemplate/change_form.html
+++ b/fiduswriter/document/templates/admin/document/documenttemplate/change_form.html
@@ -7,6 +7,11 @@
 <!-- Color variables used by the template editor components -->
 <link type="text/css" rel="stylesheet" href="{% static "css/fwtoolkit/colors.css" %}" />
 <link type="text/css" rel="stylesheet" href="{% static "css/colors.css" %}" />
+<!-- Base typography and fwtoolkit component styles required by the template editor -->
+<link type="text/css" rel="stylesheet" href="{% static "css/fonts.css" %}" />
+<link type="text/css" rel="stylesheet" href="{% static "css/text.css" %}" />
+<link type="text/css" rel="stylesheet" href="{% static "css/fwtoolkit/fwtoolkit.css" %}" />
+<link type="text/css" rel="stylesheet" href="{% static "css/forms.css" %}" />
 <link type="text/css" rel="stylesheet" href="{% static "css/document_template_admin.css" %}" />
 <script type="text/javascript" src="{% url 'admin:jsi18n' %}"></script>
 <!-- Translations -->

--- a/fiduswriter/document/tests/test_admin.py
+++ b/fiduswriter/document/tests/test_admin.py
@@ -110,6 +110,39 @@ class AdminTest(SeleniumHelper, ChannelsLiveServerTestCase):
         )
         print("DEBUG element state:", info, file=sys.stderr)
 
+    def _debug_overlapping_elements(self, selector):
+        """Log elements overlapping the center of the given selector."""
+        info = self.driver.execute_script(
+            """
+            const el = document.querySelector(arguments[0]);
+            if (!el) {
+                return {error: 'element not found for selector', selector: arguments[0]};
+            }
+            const rect = el.getBoundingClientRect();
+            const cx = rect.left + rect.width / 2;
+            const cy = rect.top + rect.height / 2;
+            const elements = document.elementsFromPoint(cx, cy);
+            return {
+                selector: arguments[0],
+                targetRect: rect,
+                center: {x: cx, y: cy},
+                stack: elements.slice(0, 10).map(e => ({
+                    tagName: e.tagName,
+                    id: e.id,
+                    className: e.className,
+                    computed: {
+                        zIndex: window.getComputedStyle(e).zIndex,
+                        position: window.getComputedStyle(e).position,
+                        display: window.getComputedStyle(e).display,
+                        visibility: window.getComputedStyle(e).visibility
+                    }
+                }))
+            };
+            """,
+            selector,
+        )
+        print("DEBUG overlapping elements:", info, file=sys.stderr)
+
     def test_maintenance(self):
         self.driver.get(self.base_admin_url)
         username = self.driver.find_element(By.ID, "id_username")
@@ -284,6 +317,14 @@ class AdminTest(SeleniumHelper, ChannelsLiveServerTestCase):
         document_style_element.click()
         self.driver.find_element(By.CSS_SELECTOR, "input.slug").send_keys(
             "fish"
+        )
+        print("DEBUG: before document-style submit click")
+        self._debug_dialog_state()
+        self._debug_overlapping_elements(
+            "[aria-describedby=document-style-dialog] button.fw-dark"
+        )
+        self.driver.save_screenshot(
+            "screenshots/debug-before-docstyle-submit.png"
         )
         self.driver.find_element(
             By.CSS_SELECTOR,

--- a/fiduswriter/document/tests/test_admin.py
+++ b/fiduswriter/document/tests/test_admin.py
@@ -63,6 +63,53 @@ class AdminTest(SeleniumHelper, ChannelsLiveServerTestCase):
             # Cool down
             time.sleep(self.wait_time / 3)
 
+    def _debug_dialog_state(self):
+        """Log the current state of all fw-dialog elements."""
+        info = self.driver.execute_script(
+            """
+            return Array.from(document.querySelectorAll('div.fw-dialog')).map(d => ({
+                id: d.id,
+                ariaDescribedBy: d.getAttribute('aria-describedby'),
+                style: d.getAttribute('style'),
+                rect: d.getBoundingClientRect(),
+                computed: {
+                    display: window.getComputedStyle(d).display,
+                    visibility: window.getComputedStyle(d).visibility,
+                    zIndex: window.getComputedStyle(d).zIndex,
+                    position: window.getComputedStyle(d).position,
+                    top: window.getComputedStyle(d).top,
+                    left: window.getComputedStyle(d).left
+                },
+                html: d.outerHTML.substring(0, 800)
+            }));
+            """
+        )
+        print("DEBUG dialog state:", info, file=sys.stderr)
+
+    def _debug_element_state(self, element):
+        """Log the computed state of a single element."""
+        info = self.driver.execute_script(
+            """
+            const el = arguments[0];
+            return {
+                tagName: el.tagName,
+                id: el.id,
+                className: el.className,
+                rect: el.getBoundingClientRect(),
+                computed: {
+                    display: window.getComputedStyle(el).display,
+                    visibility: window.getComputedStyle(el).visibility,
+                    zIndex: window.getComputedStyle(el).zIndex,
+                    position: window.getComputedStyle(el).position,
+                    pointerEvents: window.getComputedStyle(el).pointerEvents
+                },
+                html: el.outerHTML.substring(0, 800)
+            };
+            """,
+            element,
+        )
+        print("DEBUG element state:", info, file=sys.stderr)
+
     def test_maintenance(self):
         self.driver.get(self.base_admin_url)
         username = self.driver.find_element(By.ID, "id_username")
@@ -278,9 +325,25 @@ class AdminTest(SeleniumHelper, ChannelsLiveServerTestCase):
             "arguments[0].scrollIntoView(true);", export_template_element
         )
         time.sleep(0.5)
+        print("DEBUG: before .export-template click")
+        self._debug_dialog_state()
+        self.driver.save_screenshot(
+            "screenshots/debug-before-export-template-click.png"
+        )
         export_template_element.click()
+        time.sleep(0.5)
+        print("DEBUG: after .export-template click")
+        self._debug_dialog_state()
+        self.driver.save_screenshot(
+            "screenshots/debug-after-export-template-click.png"
+        )
         export_template_link = self.driver.find_element(
             By.CSS_SELECTOR, ".export-template-file a"
+        )
+        print("DEBUG: before .export-template-file a click")
+        self._debug_element_state(export_template_link)
+        self.driver.save_screenshot(
+            "screenshots/debug-before-export-template-link-click.png"
         )
         et_file = export_template_link.get_attribute("href").split("/")[-1]
         export_template_link.click()


### PR DESCRIPTION
Add screenshots and console logging of dialog/element state before and after the export-template click to diagnose why the dialog is not clickable in GitHub CI.